### PR TITLE
fix: 'Needs Categorization' toggle now spans all pages

### DIFF
--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -63,6 +63,7 @@ export default function TransactionsPage() {
   const [pageSize, setPageSize] = useState<number>(50);
   const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
   const [showFilters, setShowFilters] = useState(false);
+  const [uncategorisedOnly, setUncategorisedOnly] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Debounce search and amount inputs to avoid excessive queries
@@ -95,7 +96,7 @@ export default function TransactionsPage() {
   }, [filterKey]);
 
   const { data, isLoading, isFetching, error, refetch } = useQuery({
-    queryKey: ['transactions-paginated', user?.id, page, pageSize, debouncedSearch, filters.type, debouncedAmountMin, debouncedAmountMax, filters.dateRange.from?.toISOString(), filters.dateRange.to?.toISOString()],
+    queryKey: ['transactions-paginated', user?.id, page, pageSize, debouncedSearch, filters.type, debouncedAmountMin, debouncedAmountMax, filters.dateRange.from?.toISOString(), filters.dateRange.to?.toISOString(), uncategorisedOnly],
     queryFn: async () => {
       const supabase = createClient();
       const start = (page - 1) * pageSize;
@@ -139,6 +140,11 @@ export default function TransactionsPage() {
         if (!isNaN(max)) {
           query = query.lte('amount', max);
         }
+      }
+
+      // Apply uncategorised filter
+      if (uncategorisedOnly) {
+        query = query.is('category_id', null);
       }
 
       // Apply date range filters
@@ -464,6 +470,11 @@ export default function TransactionsPage() {
         <EnhancedTransactionList
           transactions={transactions}
           onTransactionUpdate={() => refetch()}
+          uncategorisedOnly={uncategorisedOnly}
+          onToggleUncategorisedOnly={(next) => {
+            setUncategorisedOnly(next);
+            setPage(1);
+          }}
         />
 
         {/* Pagination Controls */}

--- a/components/transactions/enhanced-transaction-list.tsx
+++ b/components/transactions/enhanced-transaction-list.tsx
@@ -34,18 +34,23 @@ interface Transaction {
 interface EnhancedTransactionListProps {
   transactions: Transaction[];
   onTransactionUpdate?: () => void;
+  uncategorisedOnly?: boolean;
+  onToggleUncategorisedOnly?: (next: boolean) => void;
 }
 
 export function EnhancedTransactionList({
   transactions,
   onTransactionUpdate,
+  uncategorisedOnly = false,
+  onToggleUncategorisedOnly,
 }: EnhancedTransactionListProps) {
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
   const [typeFilter, setTypeFilter] = useState<string>('all');
   const [categoryFilter, setCategoryFilter] = useState<string>('all');
   const [searchTerm, setSearchTerm] = useState('');
-  const [showSuggestionsOnly, setShowSuggestionsOnly] = useState(false);
   const [showNotesOnly, setShowNotesOnly] = useState(false);
+  const showSuggestionsOnly = uncategorisedOnly;
+  const setShowSuggestionsOnly = (next: boolean) => onToggleUncategorisedOnly?.(next);
   const { getMetadataForTransaction } = useTransactionMetadata();
   useCategorySuggestions();
   const { data: categories = [] } = useCategories();


### PR DESCRIPTION
## Summary

The "Needs Categorization" toggle on \`/transactions\` was filtering the current page slice **client-side**, so it would return 0 even when uncategorised transactions existed on later pages. \`/uncategorized\` was correctly showing them, which made the two pages disagree.

Confirmed in prod: 6 uncategorised transactions exist (all from Oct–Dec 2024). They live on a later page because \`/transactions\` sorts by date desc.

This PR lifts the toggle state to the page component, includes it in the query key, and applies \`.is('category_id', null)\` at the Supabase query level. Toggling now also resets to page 1.

## Test plan

- [ ] Visit \`/transactions\`, click "Needs Categorization" — it should now show 6 transactions (or whatever the current count is)
- [ ] Toggle off → returns to full paginated list
- [ ] Categorize one from the toggle view → it disappears, count drops by one
- [ ] Toggling resets to page 1