### PR TITLE
feat: pattern audit cleanup (#8)

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,0 +1,21 @@
+# Categorisation patterns — discipline notes
+
+The pattern matcher (`lib/pattern-matcher.ts`) auto-categorises transactions by regex-matching descriptions against the `categorization_patterns` table. Patterns can be hand-written or learned from `learnFromCategorization`.
+
+## Behaviours that aren't obvious from the schema
+
+- **`normalizeText` strips punctuation** before matching. `Apple.com` becomes `applecom`, `www.dtcrafts.co.uk` becomes `wwwdtcraftscouk`. Patterns containing literal `.` characters that expect punctuation will silently never match.
+- **`enforceWordBoundaries` auto-wraps single plain words.** A stored pattern `office` is matched as `\boffice\b`. Storing both `office` and `\boffice\b` is duplication, not a different rule.
+- **The matcher returns ALL matching patterns in arbitrary order.** It does not pick the most specific or highest-confidence match. Caller code is responsible for resolution.
+
+## Rules for new or learned patterns
+
+1. **No verification-suffix words.** Transactions often carry a "Verified against manual entry: …" suffix. Patterns derived from this suffix (`against`, `manual`, `entry`, `verified`, `reference`) match nearly every verified row. The `STOPWORDS` set in `lib/pattern-matcher.ts` excludes them from learning — extend it when new suffix words appear.
+2. **Word boundaries are implicit, but store them explicitly.** Single-word patterns should be stored as `\bword\b`. Future learned patterns already use this format; older unbounded twins were removed in migration 008.
+3. **No literal punctuation in patterns.** It will not match the normalised string. Use word boundaries instead.
+4. **Drawings/personal transfers should not be auto-categorised as expenditure.** Patterns like `\bcalvin\b` or `\brevolut\b` that catch person-to-person transfers will misroute drawings until Phase 6 (#2) introduces the proper "Non-business / Personal" routing.
+
+## Known unresolved issues
+
+- **Conflict resolution is unimplemented.** When two patterns target different categories (e.g. `\bplan\b` → Bank fees vs `plan\s+cashback` → Interest), the matcher returns both and the caller has no length- or specificity-based ordering. Tracked as a follow-up to #8 once the gmail spike (#9) lands.
+- **Confidence floor is unenforced.** Patterns at 60–70 confidence apply silently. A "suggest only / auto-apply" flag is on the roadmap but deferred until #9 clarifies whether patterns remain primary.

--- a/lib/pattern-matcher.ts
+++ b/lib/pattern-matcher.ts
@@ -10,6 +10,9 @@ const STOPWORDS = new Set([
   'then', 'first', 'last', 'long', 'great', 'little', 'right', 'still',
   'find', 'here', 'thing', 'many', 'well', 'transfer', 'verified', 'payment',
   'reference', 'completed',
+  // Verification-suffix words — patterns learned from these match every
+  // "Verified against manual entry: …" row, polluting categorisation.
+  'against', 'manual', 'entry',
 ]);
 
 export interface Pattern {


### PR DESCRIPTION
Closes #8.

## Summary

Audited all 63 categorization_patterns rows against current data and against the matcher behaviour in `lib/pattern-matcher.ts`. Removed 23 rows in three buckets:

- **3 verification-text leaks** (P0): `\bagainst\b`, `\bmanual\b`, `\bentry\b` — these matched the "Verified against manual entry: …" suffix that most verified rows carry, polluting categorisation across Shopify-Stripe, Undyed yarn, and Dyes.
- **2 dead patterns** (P0): `Www.dtcrafts.co.uk` (literal `.` can't match the normalised string), `\bstree\b` (fragment of Main Street, redundant).
- **18 unbounded duplicates** (P1): identical behaviour to their `\b…\b` twins because `enforceWordBoundaries` auto-wraps at match time. Pure cleanup.

Patterns: 63 → 40.

## Files

| File | Change |
|---|---|
| `lib/pattern-matcher.ts` | Add `against`, `manual`, `entry` to `STOPWORDS` so future `learnFromCategorization` calls don't recreate the verification-text leak. |
| `docs/patterns.md` | New — documents the non-obvious matcher behaviours (punctuation stripping, auto word-boundaries, no conflict resolution) and the rules for new/learned patterns. |

## Migration

`supabase/migrations/008_pattern_cleanup.sql` was applied to prod via psql. **Not in this diff** because `*.sql` is `.gitignore`d (same convention as 004–007). Backup CSV at `/tmp/herbarium-pattern-cleanup-2026-04-27/backup_patterns.csv`.

## Out of scope (deferred)

- Schema changes — `suggest_only` flag, confidence floor
- Matcher engine changes — length-based ordering for conflicts (`\bplan\b` vs `plan\s+cashback`)
- Drawings retargeting — `\bcalvin\b` and `\brevolut\b` left in place pending Phase 6 (#2)

These wait for the gmail spike (#9) to clarify whether patterns remain the primary mechanism.

## Test plan

- [ ] Re-run hq classification — Shopify-Stripe and Undyed yarn category counts should stop drifting from "Verified against manual entry" rows.
- [ ] Manually categorise a new transaction — verify the new STOPWORDS prevent `against`/`manual`/`entry` from being learned as patterns.
- [ ] Confirm no production patterns regressed (audit doc in markviewer for reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)