### PR TITLE
feat: personal spend / repayment tracking (#2)

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { StatsCards } from '@/components/dashboard/stats-cards';
 import { IncomeVsExpenditureChart } from '@/components/dashboard/income-vs-expenditure-chart';
 import { RecentTransactions } from '@/components/dashboard/recent-transactions';
 import { IncomeExpenditurePieChart } from '@/components/dashboard/category-pie-chart';
+import { PersonalBalanceCard } from '@/components/dashboard/personal-balance-card';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
 function StatsCardsSkeleton() {
@@ -78,6 +79,8 @@ export default function DashboardPage() {
         <Suspense fallback={<StatsCardsSkeleton />}>
           <StatsCards />
         </Suspense>
+
+        <PersonalBalanceCard />
 
         {/* Main Content Grid - Professional Layout */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/components/dashboard/personal-balance-card.tsx
+++ b/components/dashboard/personal-balance-card.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { ArrowDownRight, ArrowUpRight, Scale } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { usePersonalBalance } from '@/hooks/use-personal-balance';
+
+function formatCurrency(amount: number): string {
+  return `£${amount.toLocaleString('en-GB', { minimumFractionDigits: 2 })}`;
+}
+
+export function PersonalBalanceCard() {
+  const { data, isLoading, error } = usePersonalBalance();
+
+  if (isLoading) {
+    return (
+      <Card style={{ backgroundColor: '#1e1c27', borderColor: 'transparent' }} className="ring-1 ring-white/5">
+        <CardContent className="p-4">
+          <div className="h-12 bg-muted/30 rounded animate-pulse" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || !data) return null;
+
+  const { spend, repayment, net, spendCount, repaymentCount } = data;
+
+  // Hide the card entirely if there's no personal activity in this period.
+  if (spendCount === 0 && repaymentCount === 0) return null;
+
+  const balanced = Math.abs(net) < 0.01;
+  const netColor = balanced ? '#9794a8' : '#f59e0b';
+
+  return (
+    <Card style={{ backgroundColor: '#1e1c27', borderColor: 'transparent' }} className="ring-1 ring-white/5">
+      <CardContent className="p-4">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
+          {/* Spend */}
+          <div className="flex items-center gap-3">
+            <div className="rounded-md p-2" style={{ backgroundColor: 'rgba(244, 63, 94, 0.1)' }}>
+              <ArrowDownRight className="h-4 w-4" style={{ color: '#f43f5e' }} />
+            </div>
+            <div>
+              <div className="text-xs" style={{ color: '#9794a8' }}>
+                Personal Spend
+              </div>
+              <div className="text-lg font-semibold tabular-nums" style={{ color: '#f43f5e' }}>
+                {formatCurrency(spend)}
+              </div>
+              <div className="text-[11px]" style={{ color: '#9794a8' }}>
+                {spendCount} {spendCount === 1 ? 'item' : 'items'}
+              </div>
+            </div>
+          </div>
+
+          {/* Repayment */}
+          <div className="flex items-center gap-3">
+            <div className="rounded-md p-2" style={{ backgroundColor: 'rgba(16, 185, 129, 0.1)' }}>
+              <ArrowUpRight className="h-4 w-4" style={{ color: '#10b981' }} />
+            </div>
+            <div>
+              <div className="text-xs" style={{ color: '#9794a8' }}>
+                Personal Repayment
+              </div>
+              <div className="text-lg font-semibold tabular-nums" style={{ color: '#10b981' }}>
+                {formatCurrency(repayment)}
+              </div>
+              <div className="text-[11px]" style={{ color: '#9794a8' }}>
+                {repaymentCount} {repaymentCount === 1 ? 'item' : 'items'}
+              </div>
+            </div>
+          </div>
+
+          {/* Net */}
+          <div className="flex items-center gap-3">
+            <div
+              className="rounded-md p-2"
+              style={{ backgroundColor: balanced ? 'rgba(151, 148, 168, 0.1)' : 'rgba(245, 158, 11, 0.12)' }}
+            >
+              <Scale className="h-4 w-4" style={{ color: netColor }} />
+            </div>
+            <div>
+              <div className="text-xs" style={{ color: '#9794a8' }}>
+                Net imbalance
+              </div>
+              <div className="text-lg font-semibold tabular-nums" style={{ color: netColor }}>
+                {formatCurrency(net)}
+              </div>
+              <div className="text-[11px]" style={{ color: balanced ? '#9794a8' : '#f59e0b' }}>
+                {balanced ? 'Balanced' : 'Needs repayment matching'}
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-personal-balance.ts
+++ b/hooks/use-personal-balance.ts
@@ -1,0 +1,102 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/supabase/client';
+import { useAuth } from '@/lib/auth-context';
+import { useDateFilter } from '@/lib/date-filter-context';
+
+interface PersonalBalance {
+  spend: number;
+  repayment: number;
+  net: number;
+  spendCount: number;
+  repaymentCount: number;
+}
+
+function toDateString(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function getDateRange(filter: string): { start: string; end: string } {
+  const now = new Date();
+  const today = toDateString(now);
+
+  switch (filter) {
+    case 'this-month': {
+      const start = new Date(now.getFullYear(), now.getMonth(), 1);
+      return { start: toDateString(start), end: today };
+    }
+    case 'last-month': {
+      const start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      const end = new Date(now.getFullYear(), now.getMonth(), 0);
+      return { start: toDateString(start), end: toDateString(end) };
+    }
+    case 'last-3-months': {
+      const start = new Date(now.getFullYear(), now.getMonth() - 3, 1);
+      return { start: toDateString(start), end: today };
+    }
+    case 'this-year': {
+      // UK financial year — Apr 1 to Mar 31
+      const fyStart = now.getMonth() >= 3
+        ? new Date(now.getFullYear(), 3, 1)
+        : new Date(now.getFullYear() - 1, 3, 1);
+      return { start: toDateString(fyStart), end: today };
+    }
+    case 'year-to-date': {
+      const start = new Date(now.getFullYear(), 0, 1);
+      return { start: toDateString(start), end: today };
+    }
+    case 'all-time':
+    default:
+      return { start: '1970-01-01', end: today };
+  }
+}
+
+export function usePersonalBalance() {
+  const { user } = useAuth();
+  const { dateFilter } = useDateFilter();
+
+  return useQuery<PersonalBalance>({
+    queryKey: ['personal-balance', user?.id, dateFilter],
+    enabled: !!user?.id,
+    queryFn: async () => {
+      const supabase = createClient();
+      const { start, end } = getDateRange(dateFilter);
+
+      const { data, error } = await supabase
+        .from('transactions')
+        .select('amount, categories:category_id(name)')
+        .eq('type', 'capital')
+        .gte('transaction_date', start)
+        .lte('transaction_date', end);
+
+      if (error) throw error;
+
+      let spend = 0;
+      let repayment = 0;
+      let spendCount = 0;
+      let repaymentCount = 0;
+
+      for (const row of data || []) {
+        const cat = Array.isArray(row.categories) ? row.categories[0] : row.categories;
+        const name = cat?.name;
+        const amount = Number(row.amount);
+        if (name === 'Personal Spend') {
+          spend += amount;
+          spendCount += 1;
+        } else if (name === 'Personal Repayment') {
+          repayment += amount;
+          repaymentCount += 1;
+        }
+      }
+
+      return {
+        spend,
+        repayment,
+        net: spend - repayment,
+        spendCount,
+        repaymentCount,
+      };
+    },
+  });
+}

--- a/supabase/migrations/010_personal_categories.sql
+++ b/supabase/migrations/010_personal_categories.sql
@@ -1,0 +1,30 @@
+-- Migration 010 — Personal spend / repayment categories (issue #2 / Phase 6)
+--
+-- Renames the prior "Non-Business / Personal" category (created 2026-04-27 as
+-- the first concrete step of Phase 6) to "Personal Spend" to match the issue
+-- spec, and adds the matching "Personal Repayment" injection-side category so
+-- spend ↔ repayment can be paired by the dashboard widget.
+--
+-- Both are capital-typed; existing stats/Bank Position math already folds
+-- capital movements correctly (drawings reduce, injections add).
+
+BEGIN;
+
+UPDATE categories
+SET name = 'Personal Spend'
+WHERE user_id = 'bf0ad2c4-9183-409b-97a0-9bf170422fa8'
+  AND name = 'Non-Business / Personal'
+  AND type = 'capital';
+
+INSERT INTO categories (id, user_id, name, type, capital_movement_type, color, created_at)
+VALUES (
+  gen_random_uuid(),
+  'bf0ad2c4-9183-409b-97a0-9bf170422fa8',
+  'Personal Repayment',
+  'capital',
+  'injection',
+  '#10b981',
+  now()
+);
+
+COMMIT;


### PR DESCRIPTION
Closes #2.

## Summary

Phase 6 — gives Debbie a clean way to run occasional personal spend through the business account without polluting the P&L, plus a dashboard widget that flags when spend / repayment doesn't net to zero.

## Changes

| File | What |
|---|---|
| \`supabase/migrations/010_personal_categories.sql\` | Renames \`Non-Business / Personal\` → \`Personal Spend\`. Adds \`Personal Repayment\` (capital/injection). Already applied to prod. |
| \`hooks/use-personal-balance.ts\` | React Query hook keyed on date-filter context. Returns \`{spend, repayment, net, counts}\`. |
| \`components/dashboard/personal-balance-card.tsx\` | Compact 3-cell card: Spend / Repayment / Net imbalance. Hides itself when there's no personal activity in the period. Amber + "Needs repayment matching" when net ≠ 0. |
| \`app/(dashboard)/dashboard/page.tsx\` | Slotted between StatsCards and the main grid. |

## Why capital, not a new tx type

Issue spec's short-term plan: reuse \`capital\` — personal spend looks like a drawing, repayment looks like an injection. Bank Position math already folds capital movements correctly so no changes to existing stats hooks or P&L logic. If the capital framing proves confusing in real use, we promote to a proper \`non_business\` tx type — separate issue when/if needed.

## Behaviour

- **No activity** → widget doesn't render at all (no clutter on a clean dashboard)
- **Activity, balanced** → grey "Balanced" indicator, all three numbers visible
- **Activity, imbalanced** → amber net cell + "Needs repayment matching" hint

## Out of scope (intentional)

- Retroactive retagging of Misc rows that may be personal — handled case-by-case via the xlsx workflow
- Long-term \`non_business\` tx type — defer until/unless the capital workaround surfaces a real confusion

## Test plan

- [ ] Visit dashboard with date filter on \`all-time\` — should show 2 items / £94.98 spend, £0 repayment, £94.98 amber imbalance (the 2 routed during the hq cleanup)
- [ ] Add a Personal Repayment transaction equal to the spend — net should go to £0 and turn grey
- [ ] Switch date filter to \`this-month\` — widget should disappear (no personal activity in April)

🤖 Generated with [Claude Code](https://claude.com/claude-code)