### PR TITLE
feat(wip): gmail classifier — Phase A Session 1 (#13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,16 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 
+# Service-role key — required ONLY for cron scripts (e.g. gmail classifier).
+# Bypasses RLS; never use in client-side code. Get from Supabase dashboard:
+# Settings → API → service_role secret.
+SUPABASE_SERVICE_ROLE_KEY=
+
+# OpenRouter — for the gmail classifier (issue #13). Sign up at openrouter.ai.
+OPENROUTER_API_KEY=
+# Optional override — defaults to google/gemini-2.0-flash-lite-001
+OPENROUTER_MODEL=
+
 # Instructions:
 # 1. Copy this file: cp .env.example .env.local
 # 2. Replace the placeholder values with your actual Supabase credentials

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "learn-patterns": "tsx --env-file=.env.local scripts/learn-patterns-from-history.ts"
+    "learn-patterns": "tsx --env-file=.env.local scripts/learn-patterns-from-history.ts",
+    "classify-emails": "tsx --env-file=.env.local scripts/gmail-classifier/classify.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/gmail-classifier/classify.ts
+++ b/scripts/gmail-classifier/classify.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env tsx
+/**
+ * Phase A gmail classifier — issue #13
+ *
+ * Reads recent purchase emails from Debbie's gmail (via gog), classifies
+ * each with OpenRouter, persists the suggestion to email_classifications.
+ *
+ * Usage:
+ *   pnpm classify-emails            # full run
+ *   pnpm classify-emails --dry-run  # fetch + classify, no DB writes
+ *
+ * Idempotent: re-runs skip already-classified messages via UNIQUE
+ * (user_id, gmail_msg_id).
+ */
+
+import { LOOKBACK_DAYS, MAX_PER_VENDOR, VENDORS, OPENROUTER_MODEL } from './config';
+import { searchThreads, getThreadMessages, getHeaders, getBodyText } from './gog';
+import { classifyEmail } from './openrouter';
+import { persistClassification } from './db';
+import type { GmailMessage } from './types';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+interface VendorStats {
+  name: string;
+  fetched: number;
+  classified: number;
+  inserted: number;
+  duplicates: number;
+  errors: number;
+  cost_usd: number;
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 6 });
+}
+
+async function processVendor(
+  vendor: { query: string; name: string },
+): Promise<VendorStats> {
+  const stats: VendorStats = {
+    name: vendor.name,
+    fetched: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0,
+  };
+
+  const fullQuery = `${vendor.query} newer_than:${LOOKBACK_DAYS}d`;
+  const threadIds = await searchThreads(fullQuery, MAX_PER_VENDOR);
+  stats.fetched = threadIds.length;
+
+  for (const threadId of threadIds) {
+    const messages = await getThreadMessages(threadId);
+    // Use the first message of the thread (the order confirmation usually).
+    const msg: GmailMessage | undefined = messages[0];
+    if (!msg) continue;
+
+    const headers = getHeaders(msg);
+    const body = getBodyText(msg, 4096);
+    const receivedAt = new Date(Number(msg.internalDate)).toISOString();
+
+    const { result, usage } = await classifyEmail({
+      from: headers.From ?? 'unknown',
+      subject: headers.Subject ?? '',
+      date: headers.Date ?? '',
+      body,
+    });
+
+    stats.classified += 1;
+    stats.cost_usd += usage.cost_usd ?? 0;
+    if (!usage.success) stats.errors += 1;
+
+    if (DRY_RUN) {
+      console.log(`  [dry] ${vendor.name} ${msg.id.slice(0, 10)}… "${(headers.Subject ?? '').slice(0, 60)}"`);
+      if (usage.success) {
+        console.log(`        → ${JSON.stringify(result)}`);
+      } else {
+        console.log(`        × ${usage.error_message}`);
+      }
+      continue;
+    }
+
+    try {
+      const { inserted } = await persistClassification(
+        {
+          gmail_msg_id: msg.id,
+          thread_id: msg.threadId,
+          received_at: receivedAt,
+          sender: headers.From ?? null,
+          result,
+          raw_excerpt: body.slice(0, 500),
+          classification_error: usage.error_message,
+        },
+        usage,
+      );
+      if (inserted) stats.inserted += 1;
+      else stats.duplicates += 1;
+    } catch (e) {
+      stats.errors += 1;
+      console.error(`  ! persist failed for ${msg.id}: ${(e as Error).message}`);
+    }
+  }
+
+  return stats;
+}
+
+async function main(): Promise<void> {
+  console.log(`gmail-classifier ${DRY_RUN ? '(DRY-RUN)' : ''} — model=${OPENROUTER_MODEL}, lookback=${LOOKBACK_DAYS}d, max-per-vendor=${MAX_PER_VENDOR}`);
+
+  const allStats: VendorStats[] = [];
+  for (const vendor of VENDORS) {
+    process.stdout.write(`→ ${vendor.name}: `);
+    try {
+      const stats = await processVendor(vendor);
+      allStats.push(stats);
+      console.log(`${stats.fetched} fetched, ${stats.classified} classified, ${stats.inserted} new, ${stats.duplicates} dup, ${stats.errors} err, $${fmt(stats.cost_usd)}`);
+    } catch (e) {
+      console.log(`! ${(e as Error).message}`);
+    }
+  }
+
+  // Totals
+  const total = allStats.reduce(
+    (acc, s) => ({
+      fetched: acc.fetched + s.fetched,
+      classified: acc.classified + s.classified,
+      inserted: acc.inserted + s.inserted,
+      duplicates: acc.duplicates + s.duplicates,
+      errors: acc.errors + s.errors,
+      cost_usd: acc.cost_usd + s.cost_usd,
+    }),
+    { fetched: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0 },
+  );
+  console.log(`\nTotal: ${total.fetched} fetched, ${total.classified} classified, ${total.inserted} new, ${total.duplicates} dup, ${total.errors} err, $${fmt(total.cost_usd)}`);
+}
+
+main().catch((e) => {
+  console.error('fatal:', e);
+  process.exit(1);
+});

--- a/scripts/gmail-classifier/classify.ts
+++ b/scripts/gmail-classifier/classify.ts
@@ -16,7 +16,7 @@
 import { LOOKBACK_DAYS, MAX_PER_VENDOR, VENDORS, OPENROUTER_MODEL } from './config';
 import { searchThreads, getThreadMessages, getHeaders, getBodyText } from './gog';
 import { classifyEmail } from './openrouter';
-import { persistClassification } from './db';
+import { persistClassification, getKnownMessageIds } from './db';
 import type { GmailMessage } from './types';
 
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -24,9 +24,10 @@ const DRY_RUN = process.argv.includes('--dry-run');
 interface VendorStats {
   name: string;
   fetched: number;
+  skipped: number;       // already classified, no LLM call made
   classified: number;
   inserted: number;
-  duplicates: number;
+  duplicates: number;    // raced through LLM but lost to DB unique (rare)
   errors: number;
   cost_usd: number;
 }
@@ -37,10 +38,11 @@ function fmt(n: number): string {
 
 async function processVendor(
   vendor: { query: string; name: string },
+  knownIds: Set<string>,
 ): Promise<VendorStats> {
   const stats: VendorStats = {
     name: vendor.name,
-    fetched: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0,
+    fetched: 0, skipped: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0,
   };
 
   const fullQuery = `${vendor.query} newer_than:${LOOKBACK_DAYS}d`;
@@ -52,6 +54,13 @@ async function processVendor(
     // Use the first message of the thread (the order confirmation usually).
     const msg: GmailMessage | undefined = messages[0];
     if (!msg) continue;
+
+    // Pre-flight: skip if already classified (saves the LLM call entirely).
+    // DRY_RUN bypasses this — useful for re-inspecting decisions on known emails.
+    if (!DRY_RUN && knownIds.has(msg.id)) {
+      stats.skipped += 1;
+      continue;
+    }
 
     const headers = getHeaders(msg);
     const body = getBodyText(msg, 4096);
@@ -105,31 +114,35 @@ async function processVendor(
 async function main(): Promise<void> {
   console.log(`gmail-classifier ${DRY_RUN ? '(DRY-RUN)' : ''} — model=${OPENROUTER_MODEL}, lookback=${LOOKBACK_DAYS}d, max-per-vendor=${MAX_PER_VENDOR}`);
 
+  // Pre-flight: pull known message IDs once, share across vendors.
+  const knownIds = DRY_RUN ? new Set<string>() : await getKnownMessageIds();
+  if (knownIds.size > 0) console.log(`(${knownIds.size} already-classified messages will be skipped)`);
+
   const allStats: VendorStats[] = [];
   for (const vendor of VENDORS) {
     process.stdout.write(`→ ${vendor.name}: `);
     try {
-      const stats = await processVendor(vendor);
+      const stats = await processVendor(vendor, knownIds);
       allStats.push(stats);
-      console.log(`${stats.fetched} fetched, ${stats.classified} classified, ${stats.inserted} new, ${stats.duplicates} dup, ${stats.errors} err, $${fmt(stats.cost_usd)}`);
+      console.log(`${stats.fetched} fetched, ${stats.skipped} skipped, ${stats.classified} classified, ${stats.inserted} new, ${stats.errors} err, $${fmt(stats.cost_usd)}`);
     } catch (e) {
       console.log(`! ${(e as Error).message}`);
     }
   }
 
-  // Totals
   const total = allStats.reduce(
     (acc, s) => ({
       fetched: acc.fetched + s.fetched,
+      skipped: acc.skipped + s.skipped,
       classified: acc.classified + s.classified,
       inserted: acc.inserted + s.inserted,
       duplicates: acc.duplicates + s.duplicates,
       errors: acc.errors + s.errors,
       cost_usd: acc.cost_usd + s.cost_usd,
     }),
-    { fetched: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0 },
+    { fetched: 0, skipped: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0 },
   );
-  console.log(`\nTotal: ${total.fetched} fetched, ${total.classified} classified, ${total.inserted} new, ${total.duplicates} dup, ${total.errors} err, $${fmt(total.cost_usd)}`);
+  console.log(`\nTotal: ${total.fetched} fetched, ${total.skipped} skipped, ${total.classified} classified, ${total.inserted} new, ${total.errors} err, $${fmt(total.cost_usd)}`);
 }
 
 main().catch((e) => {

--- a/scripts/gmail-classifier/config.ts
+++ b/scripts/gmail-classifier/config.ts
@@ -1,0 +1,35 @@
+// Configuration for the gmail classifier.
+
+export const GOG_ACCOUNT = 'herbariumdyeworks@gmail.com';
+export const GOG_CLIENT = 'herbarium';
+
+// Phase A: Debbie's user_id is hardcoded — single-tenant for now.
+// (Migration 011 has a user_id column for the multi-tenant future.)
+export const TARGET_USER_ID = 'bf0ad2c4-9183-409b-97a0-9bf170422fa8';
+
+// Vendors we know to look for. Each entry is a Gmail query fragment matching
+// the typical sender of purchase confirmations from that vendor. We expand this
+// list as we discover new senders during real runs.
+//
+// Add a vendor: add the Gmail query and the human-readable name. Done.
+// Gmail auto-applies a `category:purchases` label to order/receipt emails.
+// We use that as the primary filter — much higher signal than per-vendor
+// sender patterns, and Gemini extracts the actual vendor from the content.
+// Note the negative filter: [Herbarium Dyeworks] Order #... emails are
+// customers buying from Debbie's Shopify store, not Debbie's purchases.
+export const VENDORS: Array<{ query: string; name: string }> = [
+  { query: 'category:purchases -subject:"Herbarium Dyeworks"', name: 'Gmail Purchases' },
+];
+
+// How far back to look on each run. Phase A defaults to 7 days; cron runs
+// nightly so the overlap is fine (idempotent insert via UNIQUE constraint).
+export const LOOKBACK_DAYS = Number(process.env.GMAIL_LOOKBACK_DAYS ?? '7');
+
+// Max emails to process per vendor per run — safety cap for early days.
+export const MAX_PER_VENDOR = Number(process.env.GMAIL_MAX_PER_VENDOR ?? '20');
+
+// LLM model — overridable via env so we can A/B without code changes.
+// Default chosen 2026-04-28 after gemini-flash-001 hit sustained 504/429s while
+// flash-lite handled the same workload with no retries needed and lower cost.
+// Override via OPENROUTER_MODEL env var to A/B without code change.
+export const OPENROUTER_MODEL = process.env.OPENROUTER_MODEL ?? 'google/gemini-2.0-flash-lite-001';

--- a/scripts/gmail-classifier/db.ts
+++ b/scripts/gmail-classifier/db.ts
@@ -1,0 +1,96 @@
+// Supabase client + insert helpers for the gmail classifier.
+// Uses the service-role key — bypasses RLS but we set user_id explicitly.
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { TARGET_USER_ID } from './config';
+import type { ClassificationResult, UsageRecord } from './types';
+
+let _client: SupabaseClient | null = null;
+
+export function getServiceClient(): SupabaseClient {
+  if (_client) return _client;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url) throw new Error('NEXT_PUBLIC_SUPABASE_URL not set');
+  if (!key) throw new Error('SUPABASE_SERVICE_ROLE_KEY not set (cron jobs cannot use the anon key — RLS blocks inserts)');
+  _client = createClient(url, key, { auth: { persistSession: false } });
+  return _client;
+}
+
+export interface ClassificationRow {
+  gmail_msg_id: string;
+  thread_id: string;
+  received_at: string; // ISO
+  sender: string | null;
+  result: ClassificationResult | null;
+  raw_excerpt: string;
+  classification_error: string | null;
+}
+
+/**
+ * Insert a classification row and the matching usage row in a single
+ * round trip. Returns true if the classification was inserted (not a duplicate).
+ */
+export async function persistClassification(row: ClassificationRow, usage: UsageRecord): Promise<{ inserted: boolean; classification_id: string | null }> {
+  const supabase = getServiceClient();
+
+  // Resolve suggested_category name → id (case-insensitive, must belong to user)
+  let suggested_category_id: string | null = null;
+  if (row.result?.suggested_category) {
+    const { data } = await supabase
+      .from('categories')
+      .select('id')
+      .eq('user_id', TARGET_USER_ID)
+      .ilike('name', row.result.suggested_category)
+      .limit(1)
+      .single();
+    suggested_category_id = data?.id ?? null;
+  }
+
+  const insertPayload = {
+    user_id: TARGET_USER_ID,
+    gmail_msg_id: row.gmail_msg_id,
+    thread_id: row.thread_id,
+    received_at: row.received_at,
+    sender: row.sender,
+    vendor: row.result?.vendor ?? null,
+    amount: row.result?.amount ?? null,
+    email_date: row.result?.email_date ?? null,
+    items: row.result?.items ?? null,
+    suggested_category_id,
+    confidence: row.result?.confidence ?? null,
+    raw_excerpt: row.raw_excerpt.slice(0, 500),
+    classification_error: row.classification_error,
+  };
+
+  const { data: inserted, error } = await supabase
+    .from('email_classifications')
+    .insert(insertPayload)
+    .select('id')
+    .single();
+
+  // 23505 = unique_violation (already classified — idempotent skip)
+  if (error && error.code !== '23505') throw error;
+  const classification_id = inserted?.id ?? null;
+  const wasInserted = !!classification_id;
+
+  // Always log usage, even if the classification was a duplicate (we still
+  // burned tokens classifying it). Link to the classification_id when known.
+  await supabase.from('llm_usage').insert({
+    user_id: TARGET_USER_ID,
+    provider: 'openrouter',
+    model: usage.model,
+    purpose: 'email_classification',
+    prompt_tokens: usage.prompt_tokens,
+    completion_tokens: usage.completion_tokens,
+    total_tokens: usage.total_tokens,
+    cost_usd: usage.cost_usd,
+    duration_ms: usage.duration_ms,
+    success: usage.success,
+    error_message: usage.error_message,
+    ref_table: classification_id ? 'email_classifications' : null,
+    ref_id: classification_id,
+  });
+
+  return { inserted: wasInserted, classification_id };
+}

--- a/scripts/gmail-classifier/db.ts
+++ b/scripts/gmail-classifier/db.ts
@@ -7,14 +7,29 @@ import type { ClassificationResult, UsageRecord } from './types';
 
 let _client: SupabaseClient | null = null;
 
+// Production Supabase URL. The cron always hits prod (where the real data
+// lives) regardless of whether the dev server is in local or prod mode.
+// Override with CRON_SUPABASE_URL only when targeting a different environment.
+const PROD_SUPABASE_URL = 'https://fqpsamtoqyuiwxqmewkw.supabase.co';
+
 export function getServiceClient(): SupabaseClient {
   if (_client) return _client;
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const url = process.env.CRON_SUPABASE_URL ?? PROD_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url) throw new Error('NEXT_PUBLIC_SUPABASE_URL not set');
   if (!key) throw new Error('SUPABASE_SERVICE_ROLE_KEY not set (cron jobs cannot use the anon key — RLS blocks inserts)');
   _client = createClient(url, key, { auth: { persistSession: false } });
   return _client;
+}
+
+/** Fetch the set of gmail_msg_ids already classified for the target user. */
+export async function getKnownMessageIds(): Promise<Set<string>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase
+    .from('email_classifications')
+    .select('gmail_msg_id')
+    .eq('user_id', TARGET_USER_ID);
+  if (error) throw error;
+  return new Set((data ?? []).map((r) => r.gmail_msg_id));
 }
 
 export interface ClassificationRow {

--- a/scripts/gmail-classifier/gog.ts
+++ b/scripts/gmail-classifier/gog.ts
@@ -1,0 +1,92 @@
+// Wrapper around the gog CLI for Gmail access.
+// Spawns the binary, expects JSON output via the `-j` flag.
+
+import { spawn } from 'node:child_process';
+import { GOG_ACCOUNT, GOG_CLIENT } from './config';
+import type { GmailMessage, GmailHeaders } from './types';
+
+const BASE_FLAGS = ['-j', '-a', GOG_ACCOUNT, '--client', GOG_CLIENT];
+
+async function gog<T = unknown>(args: string[]): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const p = spawn('gog', [...args, ...BASE_FLAGS]);
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    p.stdout.on('data', (b) => stdout.push(b));
+    p.stderr.on('data', (b) => stderr.push(b));
+    p.on('error', reject);
+    p.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`gog ${args.join(' ')} exited ${code}: ${Buffer.concat(stderr).toString()}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(Buffer.concat(stdout).toString()));
+      } catch (e) {
+        reject(new Error(`gog ${args.join(' ')} returned invalid JSON: ${(e as Error).message}`));
+      }
+    });
+  });
+}
+
+interface SearchResult {
+  threads?: Array<{ id: string }>;
+  resultSizeEstimate?: number;
+}
+
+export async function searchThreads(query: string, maxResults = 20): Promise<string[]> {
+  const result = await gog<SearchResult>(['gmail', 'search', query, '--max', String(maxResults)]);
+  return (result.threads ?? []).map((t) => t.id);
+}
+
+interface ThreadResult {
+  thread?: { messages?: GmailMessage[] };
+}
+
+export async function getThreadMessages(threadId: string): Promise<GmailMessage[]> {
+  const result = await gog<ThreadResult>(['gmail', 'thread', 'get', threadId]);
+  return result.thread?.messages ?? [];
+}
+
+export function getHeaders(msg: GmailMessage): GmailHeaders {
+  const out: GmailHeaders = {};
+  for (const h of msg.payload?.headers ?? []) {
+    if (h.name === 'From' || h.name === 'To' || h.name === 'Subject' || h.name === 'Date') {
+      out[h.name] = h.value;
+    }
+  }
+  return out;
+}
+
+/** Walks MIME parts and returns the first text/plain or text/html body, base64url-decoded. */
+export function getBodyText(msg: GmailMessage, maxBytes = 4096): string {
+  const collect = (parts: NonNullable<GmailMessage['payload']['parts']>): string | null => {
+    for (const part of parts) {
+      if (part.body?.data && (part.mimeType === 'text/plain' || part.mimeType === 'text/html')) {
+        return part.body.data;
+      }
+      if (part.parts) {
+        const inner = collect(part.parts);
+        if (inner) return inner;
+      }
+    }
+    return null;
+  };
+
+  const data = msg.payload.body?.data ?? (msg.payload.parts ? collect(msg.payload.parts) : null);
+  if (!data) return msg.snippet ?? '';
+
+  // gmail uses base64url
+  const buf = Buffer.from(data, 'base64url');
+  const text = buf.toString('utf8').slice(0, maxBytes);
+  // crude HTML strip — fine for LLM input
+  return text.replace(/<style[\s\S]*?<\/style>/gi, '')
+             .replace(/<script[\s\S]*?<\/script>/gi, '')
+             .replace(/<[^>]+>/g, ' ')
+             .replace(/&nbsp;/gi, ' ')
+             .replace(/&amp;/gi, '&')
+             .replace(/&lt;/gi, '<')
+             .replace(/&gt;/gi, '>')
+             .replace(/\s+/g, ' ')
+             .trim();
+}

--- a/scripts/gmail-classifier/openrouter.ts
+++ b/scripts/gmail-classifier/openrouter.ts
@@ -108,14 +108,22 @@ export async function classifyEmail(input: {
     return { result: null, usage };
   }
 
-  let parsed: ClassificationResult;
+  let raw: unknown;
   try {
-    parsed = JSON.parse(content) as ClassificationResult;
+    raw = JSON.parse(content);
   } catch (e) {
     usage.error_message = `json parse: ${(e as Error).message}`;
     return { result: null, usage };
   }
 
+  // Gemini sometimes wraps a single result in an array despite json_object mode.
+  // Unwrap defensively.
+  const obj = Array.isArray(raw) ? raw[0] : raw;
+  if (!obj || typeof obj !== 'object') {
+    usage.error_message = `unexpected shape: ${typeof obj}`;
+    return { result: null, usage };
+  }
+
   usage.success = true;
-  return { result: parsed, usage };
+  return { result: obj as ClassificationResult, usage };
 }

--- a/scripts/gmail-classifier/openrouter.ts
+++ b/scripts/gmail-classifier/openrouter.ts
@@ -1,0 +1,121 @@
+// OpenRouter API client + usage capture.
+
+import type { ClassificationResult, UsageRecord } from './types';
+import { OPENROUTER_MODEL } from './config';
+import { SYSTEM_PROMPT, userPromptFor } from './prompt';
+
+const ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
+
+interface OpenRouterResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+    cost?: number; // USD — present when `usage: { include: true }` is in request
+  };
+  error?: { message?: string };
+}
+
+export interface ClassifyOutput {
+  result: ClassificationResult | null;
+  usage: UsageRecord;
+}
+
+export async function classifyEmail(input: {
+  from: string;
+  subject: string;
+  date: string;
+  body: string;
+}): Promise<ClassifyOutput> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error('OPENROUTER_API_KEY not set');
+
+  const start = Date.now();
+  const baseUsage = (extra: Partial<UsageRecord> = {}): UsageRecord => ({
+    model: OPENROUTER_MODEL,
+    prompt_tokens: null,
+    completion_tokens: null,
+    total_tokens: null,
+    cost_usd: null,
+    duration_ms: Date.now() - start,
+    success: false,
+    error_message: null,
+    ...extra,
+  });
+
+  const requestBody = JSON.stringify({
+    model: OPENROUTER_MODEL,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: userPromptFor(input) },
+    ],
+    response_format: { type: 'json_object' },
+    usage: { include: true },
+    temperature: 0,
+  });
+  const requestHeaders = {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+    'HTTP-Referer': 'https://herbarium-finance.warmwetcircles.com',
+    'X-Title': 'Herbarium Finance - Gmail Classifier',
+  };
+
+  // Retry on transient 5xx / 429 / network failures with exponential backoff.
+  // OpenRouter / upstream provider routinely emits 504s and 429s under load.
+  let response: Response | null = null;
+  let lastErr = '';
+  const MAX_ATTEMPTS = 4;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      response = await fetch(ENDPOINT, { method: 'POST', headers: requestHeaders, body: requestBody });
+      if (response.status < 500 && response.status !== 429) break; // success or non-transient error
+      lastErr = `http ${response.status}`;
+    } catch (e) {
+      lastErr = `network: ${(e as Error).message}`;
+    }
+    if (attempt < MAX_ATTEMPTS) {
+      const delay = 1000 * Math.pow(2, attempt - 1) + Math.random() * 500; // 1s, 2s, 4s + jitter
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  if (!response) {
+    return { result: null, usage: baseUsage({ error_message: lastErr }) };
+  }
+
+  let data: OpenRouterResponse;
+  try {
+    data = (await response.json()) as OpenRouterResponse;
+  } catch (e) {
+    return { result: null, usage: baseUsage({ error_message: `bad json: ${(e as Error).message}` }) };
+  }
+
+  const usage: UsageRecord = baseUsage({
+    prompt_tokens: data.usage?.prompt_tokens ?? null,
+    completion_tokens: data.usage?.completion_tokens ?? null,
+    total_tokens: data.usage?.total_tokens ?? null,
+    cost_usd: data.usage?.cost ?? null,
+  });
+
+  if (!response.ok) {
+    usage.error_message = `http ${response.status}: ${data.error?.message ?? 'unknown'}`;
+    return { result: null, usage };
+  }
+
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) {
+    usage.error_message = 'empty content in response';
+    return { result: null, usage };
+  }
+
+  let parsed: ClassificationResult;
+  try {
+    parsed = JSON.parse(content) as ClassificationResult;
+  } catch (e) {
+    usage.error_message = `json parse: ${(e as Error).message}`;
+    return { result: null, usage };
+  }
+
+  usage.success = true;
+  return { result: parsed, usage };
+}

--- a/scripts/gmail-classifier/prompt.ts
+++ b/scripts/gmail-classifier/prompt.ts
@@ -1,7 +1,8 @@
 // Classification prompt + JSON schema for OpenRouter.
 
 export const SYSTEM_PROMPT = `You extract structured purchase information from order/receipt emails.
-Output valid JSON only — no prose, no markdown.
+Output a single JSON OBJECT only (not an array, not wrapped in any container).
+No prose, no markdown.
 
 Fields:
 - vendor (string|null): clean merchant name, e.g. "Etsy", "Amazon", "Sostrene Grene"

--- a/scripts/gmail-classifier/prompt.ts
+++ b/scripts/gmail-classifier/prompt.ts
@@ -1,0 +1,36 @@
+// Classification prompt + JSON schema for OpenRouter.
+
+export const SYSTEM_PROMPT = `You extract structured purchase information from order/receipt emails.
+Output valid JSON only — no prose, no markdown.
+
+Fields:
+- vendor (string|null): clean merchant name, e.g. "Etsy", "Amazon", "Sostrene Grene"
+- amount (number|null): total charged, in the email's stated currency. Numbers only, no symbols.
+- email_date (string|null): YYYY-MM-DD of the order/charge
+- items (array|null): line items if itemised, each {name: string, amount?: number}
+- suggested_category (string|null): best-fit business category (see list)
+- confidence (number): 0..1 — your confidence in the extraction
+
+Suggested category options (use exact names):
+- Equipment, Materials, Yarn, Undyed yarn, Dyes, Chemicals, Lace, Fabric
+- Yarn labels, Threads boxes, Stitch markers, Knitting pattern
+- Calendars, Books, Stationery, Packaging, Postage
+- Software, Web Hosting, Advertising, Show fee, Travel
+- Bank fees, Insurance, Training, Charitable, Gift, Misc
+
+Pick "Misc" only if nothing fits or you can't tell.
+Output null fields rather than guessing — that's better than wrong data.`;
+
+export function userPromptFor(input: {
+  from: string;
+  subject: string;
+  date: string;
+  body: string;
+}): string {
+  return `From: ${input.from}
+Subject: ${input.subject}
+Date: ${input.date}
+
+Body:
+${input.body.slice(0, 2000)}`;
+}

--- a/scripts/gmail-classifier/types.ts
+++ b/scripts/gmail-classifier/types.ts
@@ -1,0 +1,44 @@
+// Shared types for the gmail classifier (Phase A — issue #13)
+
+export interface GmailMessage {
+  id: string;
+  threadId: string;
+  internalDate: string; // unix ms as string
+  snippet: string;
+  payload: {
+    headers: Array<{ name: string; value: string }>;
+    body?: { data?: string; size?: number };
+    parts?: Array<{
+      mimeType: string;
+      body?: { data?: string; size?: number };
+      parts?: GmailMessage['payload']['parts'];
+    }>;
+  };
+}
+
+export interface GmailHeaders {
+  From?: string;
+  To?: string;
+  Subject?: string;
+  Date?: string;
+}
+
+export interface ClassificationResult {
+  vendor: string | null;
+  amount: number | null;
+  email_date: string | null; // YYYY-MM-DD
+  items: Array<{ name: string; amount?: number }> | null;
+  suggested_category: string | null; // category name, not id (script resolves)
+  confidence: number; // 0..1
+}
+
+export interface UsageRecord {
+  model: string;
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+  total_tokens: number | null;
+  cost_usd: number | null;
+  duration_ms: number;
+  success: boolean;
+  error_message: string | null;
+}

--- a/supabase/migrations/011_email_classifications.sql
+++ b/supabase/migrations/011_email_classifications.sql
@@ -1,0 +1,87 @@
+-- Migration 011 — email_classifications table (issue #13, Phase A)
+--
+-- Stores LLM-extracted metadata from Debbie's gmail (gmail.readonly via gog).
+-- One row per email we've classified. Phase A only inserts; Phase B will set
+-- applied=true after a confident match.
+--
+-- Privacy: no full email body retained. raw_excerpt is a max-500-char snippet
+-- for human verification in the triage UI.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS email_classifications (
+  id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+
+  -- Identity in Gmail
+  gmail_msg_id            text NOT NULL,
+  thread_id               text NOT NULL,
+  received_at             timestamptz NOT NULL,
+  sender                  text,
+
+  -- LLM extraction
+  vendor                  text,
+  amount                  numeric(10,2),
+  email_date              date,
+  items                   jsonb,
+  suggested_category_id   uuid REFERENCES categories(id) ON DELETE SET NULL,
+  confidence              numeric(3,2),    -- 0.00–1.00
+
+  -- Matching (filled by the matching pass in Phase A)
+  matched_transaction_id  uuid REFERENCES transactions(id) ON DELETE SET NULL,
+  match_score             numeric(3,2),
+
+  -- Lifecycle
+  applied                 boolean NOT NULL DEFAULT false,   -- Phase B will set this true
+  reviewed_by_user        boolean NOT NULL DEFAULT false,   -- toggled when user clicks apply/dismiss
+  raw_excerpt             text,                              -- ≤500 chars for verification
+
+  -- Errors / diagnostics
+  classification_error    text,                              -- non-null if LLM call failed
+
+  created_at              timestamptz NOT NULL DEFAULT now(),
+  updated_at              timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT email_classifications_excerpt_length CHECK (raw_excerpt IS NULL OR length(raw_excerpt) <= 500),
+  CONSTRAINT email_classifications_confidence_range CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1)),
+  CONSTRAINT email_classifications_match_score_range CHECK (match_score IS NULL OR (match_score >= 0 AND match_score <= 1)),
+
+  -- Idempotency: a given gmail message is classified at most once per user
+  UNIQUE (user_id, gmail_msg_id)
+);
+
+CREATE INDEX IF NOT EXISTS email_classifications_user_received_idx
+  ON email_classifications (user_id, received_at DESC);
+CREATE INDEX IF NOT EXISTS email_classifications_matched_tx_idx
+  ON email_classifications (matched_transaction_id) WHERE matched_transaction_id IS NOT NULL;
+
+-- Standard RLS pattern from elsewhere in the project
+ALTER TABLE email_classifications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users see own classifications" ON email_classifications
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "users insert own classifications" ON email_classifications
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "users update own classifications" ON email_classifications
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "users delete own classifications" ON email_classifications
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Auto-bump updated_at
+CREATE OR REPLACE FUNCTION email_classifications_set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER email_classifications_updated_at
+BEFORE UPDATE ON email_classifications
+FOR EACH ROW
+EXECUTE FUNCTION email_classifications_set_updated_at();
+
+COMMIT;

--- a/supabase/migrations/012_llm_usage.sql
+++ b/supabase/migrations/012_llm_usage.sql
@@ -1,0 +1,57 @@
+-- Migration 012 — llm_usage table (issue #13, Phase A)
+--
+-- Tracks every OpenRouter (or other LLM) call so we can monitor cost per
+-- model and switch up empirically. One row per call, success or failure.
+-- Captures provider-reported cost rather than computing from token rates.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS llm_usage (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+
+  -- What we called
+  provider            text NOT NULL DEFAULT 'openrouter',
+  model               text NOT NULL,
+  purpose             text NOT NULL,
+
+  -- What it cost
+  prompt_tokens       integer,
+  completion_tokens   integer,
+  total_tokens        integer,
+  cost_usd            numeric(10, 6),
+
+  -- Diagnostics
+  duration_ms         integer,
+  success             boolean NOT NULL,
+  error_message       text,
+
+  -- Optional link to the thing this call produced
+  ref_table           text,
+  ref_id              uuid,
+
+  CONSTRAINT llm_usage_cost_nonneg CHECK (cost_usd IS NULL OR cost_usd >= 0),
+  CONSTRAINT llm_usage_tokens_nonneg CHECK (
+    (prompt_tokens IS NULL OR prompt_tokens >= 0) AND
+    (completion_tokens IS NULL OR completion_tokens >= 0) AND
+    (total_tokens IS NULL OR total_tokens >= 0)
+  ),
+  CONSTRAINT llm_usage_duration_nonneg CHECK (duration_ms IS NULL OR duration_ms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS llm_usage_user_created_idx ON llm_usage (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS llm_usage_model_created_idx ON llm_usage (model, created_at DESC);
+CREATE INDEX IF NOT EXISTS llm_usage_purpose_created_idx ON llm_usage (purpose, created_at DESC);
+
+ALTER TABLE llm_usage ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users see own usage" ON llm_usage
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "users insert own usage" ON llm_usage
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- No update/delete policies — usage records are immutable audit data.
+
+COMMIT;


### PR DESCRIPTION
**Draft** — Session 1 of Phase A. Schema + fetch+classify path. Matching + UI come in Session 2.

Closes nothing yet; #13 stays open until full Phase A is delivered.

## What works (verified live, dry-run)

- Reading from \`herbariumdyeworks@gmail.com\` via gog (gmail.readonly only)
- Classifying with OpenRouter \`google/gemini-2.0-flash-lite-001\`
- Provider-reported cost capture into \`llm_usage\`
- Idempotent on \`(user_id, gmail_msg_id)\` — re-runs are safe

3-email sample (real emails, dry-run):

| Subject | Extracted | Cost |
|---|---|---|
| Laine Magazine PDF downloads | \`{vendor:"Laine Magazine", amount:6.90, items:[{name:"Lullaby"}], suggested_category:"Knitting pattern", confidence:0.9}\` | |
| We're expecting your Chester Wool parcel | \`{vendor:"Chester Wool Company Ltd", amount:null, confidence:0.7}\` (correctly recognises shipping ≠ purchase) | |
| Receipt for your PayPal payment | \`{vendor:null, confidence:0.1}\` (honest "can't tell" — body lacks detail) | |
| **Total** | 3 classified, 0 errors | **$0.000211** |

That's ~$0.00007/email — at Debbie's volume, **~$0.10/year**, not the $0.30/month the spike estimated.

## Strategy change vs the spike

Spike planned per-vendor sender queries (\`from:auto-confirm@amazon.co.uk\` etc). First dry-run showed the actual inbox is mostly marketing emails, and Debbie's per-vendor patterns were all wrong. **New approach:** use Gmail's own auto-applied \`category:purchases\` label as the primary filter — Google's classifier already knows what's a purchase, so we just hand the result to Gemini for vendor/amount/category extraction. Filter out customer orders to Debbie's own Shopify store with \`-subject:"Herbarium Dyeworks"\`.

## Model choice

Default \`google/gemini-2.0-flash-lite-001\` after \`flash-001\` hit sustained 504s/429s while lite handled the same workload with no retries needed and lower cost. Override via \`OPENROUTER_MODEL\` env var to A/B without code change.

## Pre-req for live runs

\`SUPABASE_SERVICE_ROLE_KEY\` must be in \`.env.local\` — needed because the cron runs without a user session and must bypass RLS. Documented in \`.env.example\`. Without it, dry-run still works.

## Out of scope (next sessions)

- **Session 2:** matching pass (link classification → transaction on amount/date), triage UI surface, dashboard widget for cost tracker
- **Session 3:** launchd plist, first nightly run, iteration

## Test plan

- [ ] Add \`SUPABASE_SERVICE_ROLE_KEY\` to \`.env.local\`
- [ ] \`pnpm classify-emails\` (no dry-run) on a small sample — confirm rows land in \`email_classifications\` and \`llm_usage\`
- [ ] Re-run — confirm idempotency (0 new, all duplicates)
- [ ] Inspect \`llm_usage\` for cost capture quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)