### PR TITLE
feat(gmail): matching pass + triage UI + cost widget (#13 session 2)

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { IncomeVsExpenditureChart } from '@/components/dashboard/income-vs-expen
 import { RecentTransactions } from '@/components/dashboard/recent-transactions';
 import { IncomeExpenditurePieChart } from '@/components/dashboard/category-pie-chart';
 import { PersonalBalanceCard } from '@/components/dashboard/personal-balance-card';
+import { LlmCostCard } from '@/components/dashboard/llm-cost-card';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
 function StatsCardsSkeleton() {
@@ -81,6 +82,8 @@ export default function DashboardPage() {
         </Suspense>
 
         <PersonalBalanceCard />
+
+        <LlmCostCard />
 
         {/* Main Content Grid - Professional Layout */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/app/(dashboard)/uncategorized/page.tsx
+++ b/app/(dashboard)/uncategorized/page.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/supabase/client';
 import { useAuth } from '@/lib/auth-context';
 import { useCategories, type Category } from '@/hooks/use-categories';
+import { useEmailSuggestions } from '@/hooks/use-email-suggestions';
 import { PageLayout, PageSection, PageEmptyState } from '@/components/ui/page-layout';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -23,6 +24,8 @@ import {
   RefreshCw,
   Loader2,
   List,
+  Mail,
+  Sparkles,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { PatternMatcher } from '@/lib/pattern-matcher';
@@ -146,6 +149,9 @@ export default function UncategorizedPage() {
   const transactions = data?.transactions || [];
   const totalCount = data?.totalCount || 0;
   const totalPages = data?.totalPages || 0;
+
+  // Fetch email-classification suggestions for the visible transactions.
+  const { data: suggestions } = useEmailSuggestions(transactions.map(t => t.id));
 
   // Helper: get categories matching a transaction type
   const categoriesForType = (type: string): Category[] =>
@@ -276,12 +282,14 @@ export default function UncategorizedPage() {
           {transactions.map((tx) => {
             const matchingCategories = categoriesForType(tx.type);
             const isAssigning = assigningId === tx.id;
+            const suggestion = suggestions?.get(tx.id);
 
             return (
               <div
                 key={tx.id}
-                className="flex flex-col sm:flex-row sm:items-center gap-3 py-4 first:pt-0 last:pb-0"
+                className="py-4 first:pt-0 last:pb-0"
               >
+                <div className="flex flex-col sm:flex-row sm:items-center gap-3">
                 {/* Left: description + date */}
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-foreground truncate">
@@ -345,6 +353,59 @@ export default function UncategorizedPage() {
                     )}
                   </div>
                 </div>
+                </div>
+
+                {/* Email-classification evidence panel */}
+                {suggestion && (
+                  <div className="mt-3 ml-0 sm:ml-4 rounded-md border border-sky-500/25 bg-sky-500/5 p-3">
+                    <div className="flex items-start gap-3">
+                      <Mail className="w-4 h-4 mt-0.5 text-sky-500 flex-shrink-0" />
+                      <div className="flex-1 min-w-0 space-y-2">
+                        <div className="flex flex-wrap items-center gap-2 text-xs">
+                          <span className="font-medium text-foreground">
+                            {suggestion.vendor ?? 'Unknown vendor'}
+                          </span>
+                          {suggestion.email_date && (
+                            <span className="text-muted-foreground">
+                              · email {formatDate(suggestion.email_date)}
+                            </span>
+                          )}
+                          {suggestion.match_score != null && (
+                            <Badge variant="outline" className="bg-sky-500/15 text-sky-500 border-sky-500/25">
+                              match {Math.round(suggestion.match_score * 100)}%
+                            </Badge>
+                          )}
+                          {suggestion.sender && (
+                            <span className="text-muted-foreground truncate">
+                              · {suggestion.sender}
+                            </span>
+                          )}
+                        </div>
+                        {suggestion.raw_excerpt && (
+                          <p className="text-xs text-muted-foreground line-clamp-2">
+                            {suggestion.raw_excerpt}
+                          </p>
+                        )}
+                        {suggestion.suggested_category_id && suggestion.suggested_category_name && (
+                          <div className="flex items-center gap-2 pt-1">
+                            <Sparkles className="w-3.5 h-3.5 text-sky-500" />
+                            <span className="text-xs text-muted-foreground">Suggested:</span>
+                            <Badge variant="outline">{suggestion.suggested_category_name}</Badge>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="h-7 text-xs"
+                              disabled={isAssigning}
+                              onClick={() => handleAssign(tx.id, suggestion.suggested_category_id!)}
+                            >
+                              Apply suggestion
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/components/dashboard/llm-cost-card.tsx
+++ b/components/dashboard/llm-cost-card.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { Mail, Sparkles, Coins } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { useLlmUsage } from '@/hooks/use-llm-usage';
+
+function fmtUsd(n: number): string {
+  if (n === 0) return '$0.00';
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+export function LlmCostCard() {
+  const { data, isLoading, error } = useLlmUsage();
+
+  if (isLoading) {
+    return (
+      <Card style={{ backgroundColor: '#1e1c27', borderColor: 'transparent' }} className="ring-1 ring-white/5">
+        <CardContent className="p-4">
+          <div className="h-12 bg-muted/30 rounded animate-pulse" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || !data) return null;
+  if (data.lifetimeCalls === 0) return null;
+
+  return (
+    <Card style={{ backgroundColor: '#1e1c27', borderColor: 'transparent' }} className="ring-1 ring-white/5">
+      <CardContent className="p-4">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
+          {/* This month */}
+          <div className="flex items-center gap-3">
+            <div className="rounded-md p-2" style={{ backgroundColor: 'rgba(56, 189, 248, 0.1)' }}>
+              <Coins className="h-4 w-4" style={{ color: '#38bdf8' }} />
+            </div>
+            <div>
+              <div className="text-xs" style={{ color: '#9794a8' }}>
+                Gmail AI cost · this month
+              </div>
+              <div className="text-lg font-semibold tabular-nums" style={{ color: '#38bdf8' }}>
+                {fmtUsd(data.monthCost)}
+              </div>
+              <div className="text-[11px]" style={{ color: '#9794a8' }}>
+                {data.monthCalls} {data.monthCalls === 1 ? 'classification' : 'classifications'}
+              </div>
+            </div>
+          </div>
+
+          {/* Lifetime */}
+          <div className="flex items-center gap-3">
+            <div className="rounded-md p-2" style={{ backgroundColor: 'rgba(151, 148, 168, 0.1)' }}>
+              <Mail className="h-4 w-4" style={{ color: '#9794a8' }} />
+            </div>
+            <div>
+              <div className="text-xs" style={{ color: '#9794a8' }}>
+                Lifetime
+              </div>
+              <div className="text-lg font-semibold tabular-nums" style={{ color: '#cfcdd9' }}>
+                {fmtUsd(data.lifetimeCost)}
+              </div>
+              <div className="text-[11px]" style={{ color: '#9794a8' }}>
+                {data.lifetimeCalls} {data.lifetimeCalls === 1 ? 'call' : 'calls'}
+              </div>
+            </div>
+          </div>
+
+          {/* Matched */}
+          <div className="flex items-center gap-3">
+            <div className="rounded-md p-2" style={{ backgroundColor: 'rgba(168, 85, 247, 0.1)' }}>
+              <Sparkles className="h-4 w-4" style={{ color: '#a855f7' }} />
+            </div>
+            <div>
+              <div className="text-xs" style={{ color: '#9794a8' }}>
+                Matched to transactions
+              </div>
+              <div className="text-lg font-semibold tabular-nums" style={{ color: '#a855f7' }}>
+                {data.matchedTransactions}
+              </div>
+              <div className="text-[11px]" style={{ color: '#9794a8' }}>
+                Surfaced as suggestions
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-email-suggestions.ts
+++ b/hooks/use-email-suggestions.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/supabase/client';
+import { useAuth } from '@/lib/auth-context';
+
+export interface EmailSuggestion {
+  id: string;
+  matched_transaction_id: string;
+  vendor: string | null;
+  amount: number | null;
+  email_date: string | null;
+  sender: string | null;
+  raw_excerpt: string | null;
+  confidence: number | null;
+  match_score: number | null;
+  suggested_category_id: string | null;
+  suggested_category_name: string | null;
+}
+
+/**
+ * Fetch email_classifications joined to a set of transaction IDs. Returned as
+ * a map keyed by transaction id (for O(1) lookup in the triage list).
+ *
+ * If a transaction has multiple matched emails (rare), the highest-confidence
+ * one wins.
+ */
+export function useEmailSuggestions(transactionIds: string[]) {
+  const { user } = useAuth();
+  const idsKey = [...transactionIds].sort().join(',');
+
+  return useQuery({
+    queryKey: ['email-suggestions', user?.id, idsKey],
+    enabled: !!user?.id && transactionIds.length > 0,
+    staleTime: 60 * 1000,
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data, error } = await supabase
+        .from('email_classifications')
+        .select(
+          'id, matched_transaction_id, vendor, amount, email_date, sender, raw_excerpt, confidence, match_score, suggested_category_id, categories:suggested_category_id(name)',
+        )
+        .in('matched_transaction_id', transactionIds);
+      if (error) throw error;
+
+      const byTx = new Map<string, EmailSuggestion>();
+      for (const row of data ?? []) {
+        if (!row.matched_transaction_id) continue;
+        const cat = Array.isArray(row.categories) ? row.categories[0] : row.categories;
+        const suggestion: EmailSuggestion = {
+          id: row.id,
+          matched_transaction_id: row.matched_transaction_id,
+          vendor: row.vendor,
+          amount: row.amount,
+          email_date: row.email_date,
+          sender: row.sender,
+          raw_excerpt: row.raw_excerpt,
+          confidence: row.confidence,
+          match_score: row.match_score,
+          suggested_category_id: row.suggested_category_id,
+          suggested_category_name: cat?.name ?? null,
+        };
+        const existing = byTx.get(row.matched_transaction_id);
+        const newScore = (suggestion.match_score ?? 0) + (suggestion.confidence ?? 0);
+        const oldScore = existing ? (existing.match_score ?? 0) + (existing.confidence ?? 0) : -1;
+        if (!existing || newScore > oldScore) byTx.set(row.matched_transaction_id, suggestion);
+      }
+      return byTx;
+    },
+  });
+}

--- a/hooks/use-llm-usage.ts
+++ b/hooks/use-llm-usage.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/supabase/client';
+import { useAuth } from '@/lib/auth-context';
+
+export interface LlmUsageStats {
+  monthCost: number;
+  monthCalls: number;
+  lifetimeCost: number;
+  lifetimeCalls: number;
+  matchedTransactions: number;
+}
+
+export function useLlmUsage() {
+  const { user } = useAuth();
+
+  return useQuery<LlmUsageStats>({
+    queryKey: ['llm-usage', user?.id],
+    enabled: !!user?.id,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const supabase = createClient();
+      const monthStart = (() => {
+        const d = new Date();
+        return new Date(d.getFullYear(), d.getMonth(), 1).toISOString();
+      })();
+
+      const [{ data: lifetime, error: e1 }, { data: month, error: e2 }, { count: matched, error: e3 }] = await Promise.all([
+        supabase.from('llm_usage').select('cost_usd'),
+        supabase.from('llm_usage').select('cost_usd').gte('created_at', monthStart),
+        supabase
+          .from('email_classifications')
+          .select('id', { count: 'exact', head: true })
+          .not('matched_transaction_id', 'is', null),
+      ]);
+      if (e1) throw e1;
+      if (e2) throw e2;
+      if (e3) throw e3;
+
+      const sum = (rows: { cost_usd: number | null }[] | null) =>
+        (rows ?? []).reduce((acc, r) => acc + Number(r.cost_usd ?? 0), 0);
+
+      return {
+        monthCost: sum(month),
+        monthCalls: month?.length ?? 0,
+        lifetimeCost: sum(lifetime),
+        lifetimeCalls: lifetime?.length ?? 0,
+        matchedTransactions: matched ?? 0,
+      };
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "learn-patterns": "tsx --env-file=.env.local scripts/learn-patterns-from-history.ts",
-    "classify-emails": "tsx --env-file=.env.local scripts/gmail-classifier/classify.ts"
+    "classify-emails": "tsx --env-file=.env.local scripts/gmail-classifier/classify.ts",
+    "match-emails": "tsx --env-file=.env.local scripts/gmail-classifier/matching.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/gmail-classifier/classify.ts
+++ b/scripts/gmail-classifier/classify.ts
@@ -17,6 +17,7 @@ import { LOOKBACK_DAYS, MAX_PER_VENDOR, VENDORS, OPENROUTER_MODEL } from './conf
 import { searchThreads, getThreadMessages, getHeaders, getBodyText } from './gog';
 import { classifyEmail } from './openrouter';
 import { persistClassification, getKnownMessageIds } from './db';
+import { runMatchingPass } from './matching';
 import type { GmailMessage } from './types';
 
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -143,6 +144,13 @@ async function main(): Promise<void> {
     { fetched: 0, skipped: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0 },
   );
   console.log(`\nTotal: ${total.fetched} fetched, ${total.skipped} skipped, ${total.classified} classified, ${total.inserted} new, ${total.errors} err, $${fmt(total.cost_usd)}`);
+
+  // Matching pass — link unmatched classifications to bank transactions.
+  // Skipped on dry-run since nothing was inserted.
+  if (!DRY_RUN) {
+    const m = await runMatchingPass();
+    console.log(`Matching: ${m.considered} considered, ${m.matched} matched, ${m.ambiguous} ambiguous, ${m.no_candidate} no candidate`);
+  }
 }
 
 main().catch((e) => {

--- a/scripts/gmail-classifier/matching.ts
+++ b/scripts/gmail-classifier/matching.ts
@@ -1,0 +1,137 @@
+// Matching pass — link email_classifications to transactions on (amount, date ±3d).
+//
+// Phase A scoring (issue #13):
+//   amount must equal exactly (no fuzz)
+//   |date diff| 0 → 1.00, 1 → 0.85, 2 → 0.70, 3 → 0.55
+//   type filter: expenditure only (purchase emails are expenses)
+//
+// We only persist the match if there is a single best candidate above the
+// threshold. Ambiguous matches (two transactions tied on score) are left
+// unmatched — the user resolves them manually.
+
+import { getServiceClient } from './db';
+import { TARGET_USER_ID } from './config';
+
+const WINDOW_DAYS = 3;
+const MIN_SCORE = 0.55;
+
+interface Classification {
+  id: string;
+  amount: number;
+  email_date: string; // YYYY-MM-DD
+}
+
+interface Candidate {
+  id: string;
+  transaction_date: string;
+  amount: number;
+}
+
+export interface MatchingStats {
+  considered: number;
+  matched: number;
+  ambiguous: number;
+  no_candidate: number;
+}
+
+function scoreFor(diffDays: number): number {
+  const d = Math.abs(diffDays);
+  if (d === 0) return 1.0;
+  if (d === 1) return 0.85;
+  if (d === 2) return 0.70;
+  if (d === 3) return 0.55;
+  return 0;
+}
+
+function daysBetween(a: string, b: string): number {
+  const ms = new Date(a).getTime() - new Date(b).getTime();
+  return Math.round(ms / 86_400_000);
+}
+
+function shiftDate(iso: string, days: number): string {
+  const d = new Date(iso);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export async function runMatchingPass(): Promise<MatchingStats> {
+  const supabase = getServiceClient();
+  const stats: MatchingStats = { considered: 0, matched: 0, ambiguous: 0, no_candidate: 0 };
+
+  // Pull all unmatched classifications with the data we need to match on.
+  const { data: classifications, error } = await supabase
+    .from('email_classifications')
+    .select('id, amount, email_date')
+    .eq('user_id', TARGET_USER_ID)
+    .is('matched_transaction_id', null)
+    .not('amount', 'is', null)
+    .not('email_date', 'is', null);
+  if (error) throw error;
+
+  const rows = (classifications ?? []) as Classification[];
+  stats.considered = rows.length;
+
+  for (const c of rows) {
+    const lo = shiftDate(c.email_date, -WINDOW_DAYS);
+    const hi = shiftDate(c.email_date, WINDOW_DAYS);
+
+    const { data: candidates, error: cErr } = await supabase
+      .from('transactions')
+      .select('id, transaction_date, amount')
+      .eq('user_id', TARGET_USER_ID)
+      .eq('type', 'expenditure')
+      .eq('amount', c.amount)
+      .gte('transaction_date', lo)
+      .lte('transaction_date', hi);
+    if (cErr) throw cErr;
+
+    const cands = (candidates ?? []) as Candidate[];
+    if (cands.length === 0) {
+      stats.no_candidate += 1;
+      continue;
+    }
+
+    const scored = cands
+      .map((tx) => ({ tx, score: scoreFor(daysBetween(tx.transaction_date, c.email_date)) }))
+      .filter((s) => s.score >= MIN_SCORE)
+      .sort((a, b) => b.score - a.score);
+
+    if (scored.length === 0) {
+      stats.no_candidate += 1;
+      continue;
+    }
+
+    // Ambiguous: top two share the same score → don't guess
+    if (scored.length > 1 && scored[0].score === scored[1].score) {
+      stats.ambiguous += 1;
+      continue;
+    }
+
+    const best = scored[0];
+    const { error: uErr } = await supabase
+      .from('email_classifications')
+      .update({
+        matched_transaction_id: best.tx.id,
+        match_score: best.score,
+      })
+      .eq('id', c.id);
+    if (uErr) throw uErr;
+    stats.matched += 1;
+  }
+
+  return stats;
+}
+
+// Allow running standalone: `tsx scripts/gmail-classifier/matching.ts`
+if (require.main === module) {
+  runMatchingPass()
+    .then((s) => {
+      console.log(
+        `matching: ${s.considered} considered, ${s.matched} matched, ${s.ambiguous} ambiguous, ${s.no_candidate} no candidate`,
+      );
+    })
+    .catch((e) => {
+      console.error('fatal:', e);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- Matching pass links `email_classifications` → `transactions` on amount equality + date ±3d. Scoring 1.00 / 0.85 / 0.70 / 0.55; drops ambiguous ties (top two same score). Runs as a final step in `classify-emails` and standalone via `pnpm match-emails`.
- Uncategorised triage page now shows an inline evidence panel for any matched row: vendor, sender, email date, excerpt, match-% badge, and a one-click **Apply suggestion** that assigns the LLM-suggested category.
- New dashboard widget summarises Gmail-AI spend (this month, lifetime, matched-tx count). Self-hides when `llm_usage` is empty.

Closes part of #13 (Phase A Session 2). Session 3 = launchd plist + first live week.

First live matching pass: `1 considered, 0 matched, 0 ambiguous, 1 no candidate` — expected with 3 seeded classifications.

## Test plan
- [ ] `pnpm classify-emails` runs end-to-end and prints a `Matching: …` summary line at the end
- [ ] `pnpm match-emails` works standalone
- [ ] Dashboard renders the LLM cost card now that usage exists; hides for users with no usage
- [ ] Uncategorised page renders normally when there are no matched suggestions
- [ ] Apply-suggestion button categorises the transaction (verify via toast + list refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)