### PR TITLE
fix(rls): shared access for gmail classifier tables (#13)

### DIFF
--- a/supabase/migrations/013_shared_access_for_gmail_tables.sql
+++ b/supabase/migrations/013_shared_access_for_gmail_tables.sql
@@ -1,0 +1,53 @@
+-- Migration 013 — relax RLS on email_classifications + llm_usage so any
+-- authenticated user (Calvin or Debbie) can see and act on the data.
+--
+-- The rest of the schema already uses auth.role() = 'authenticated' policies;
+-- migrations 011/012 mistakenly used the per-user auth.uid() = user_id shape,
+-- which hid all classification + LLM-cost data from anyone other than the
+-- TARGET_USER_ID the cron writes under (Debbie). This migration aligns those
+-- two tables with the rest of the schema.
+--
+-- user_id columns stay on the rows for audit / provenance — only visibility
+-- and write-permission gates change.
+
+BEGIN;
+
+-- ===== email_classifications =====
+DROP POLICY IF EXISTS "users see own classifications"   ON email_classifications;
+DROP POLICY IF EXISTS "users insert own classifications" ON email_classifications;
+DROP POLICY IF EXISTS "users update own classifications" ON email_classifications;
+DROP POLICY IF EXISTS "users delete own classifications" ON email_classifications;
+
+CREATE POLICY "Authenticated users can view all email classifications"
+  ON email_classifications FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+-- INSERT forces the row's user_id to the caller — keeps the audit trail
+-- accurate when a human (not the cron / service role) inserts a row.
+CREATE POLICY "Authenticated users can insert email classifications"
+  ON email_classifications FOR INSERT
+  WITH CHECK (auth.role() = 'authenticated' AND user_id = auth.uid());
+
+CREATE POLICY "Authenticated users can update all email classifications"
+  ON email_classifications FOR UPDATE
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Authenticated users can delete all email classifications"
+  ON email_classifications FOR DELETE
+  USING (auth.role() = 'authenticated');
+
+-- ===== llm_usage =====
+DROP POLICY IF EXISTS "users see own usage"   ON llm_usage;
+DROP POLICY IF EXISTS "users insert own usage" ON llm_usage;
+
+CREATE POLICY "Authenticated users can view all llm usage"
+  ON llm_usage FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Authenticated users can insert llm usage"
+  ON llm_usage FOR INSERT
+  WITH CHECK (auth.role() = 'authenticated' AND user_id = auth.uid());
+
+-- No UPDATE/DELETE policies on llm_usage — audit records stay immutable.
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Migrations 011/012 mistakenly used per-user RLS (\`auth.uid() = user_id\`) on \`email_classifications\` + \`llm_usage\`, hiding data from anyone other than the cron's TARGET_USER_ID
- This migration realigns those two tables with the project's standard "any authenticated user" RLS shape used by transactions, categories, patterns, etc.
- INSERTs still self-stamp \`user_id = auth.uid()\` (audit trail intact); SELECT/UPDATE/DELETE open to any authenticated user
- Service-role key (cron) bypasses RLS unchanged

**Applied to prod 2026-04-30** via libpq psql on the transaction pooler. Verified via \`pg_policies\`.

## Test plan
- [ ] Log into prod as Calvin (not Debbie) — dashboard cost card now appears with the existing 3 classifications
- [ ] No regression on existing tables (transactions, categories, etc — unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)