### PR TITLE
feat: AI Usage page + cascading category delete

### DIFF
--- a/app/(dashboard)/ai-usage/page.tsx
+++ b/app/(dashboard)/ai-usage/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+import { PageLayout, PageSection } from '@/components/ui/page-layout';
+import { LlmCostCard } from '@/components/dashboard/llm-cost-card';
+
+export default function AiUsagePage() {
+  return (
+    <PageLayout
+      title="AI Usage"
+      description="OpenRouter / LLM cost tracking for the Gmail purchase classifier and any other AI features."
+      icon={Sparkles}
+    >
+      <PageSection
+        title="Spend"
+        description="This month, lifetime, and how many transactions have been linked to a classified email."
+        icon={Sparkles}
+      >
+        <LlmCostCard />
+      </PageSection>
+    </PageLayout>
+  );
+}

--- a/app/(dashboard)/categories/page.tsx
+++ b/app/(dashboard)/categories/page.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { PageLayout } from '@/components/ui/page-layout';
-import { useCategories, useCategoryMutations, useCategoryStats } from '@/hooks/use-categories';
+import { useCategories, useCategoryMutations, useCategoryStats, fetchCategoryDeleteImpact } from '@/hooks/use-categories';
 import { useCategoryHierarchiesWithCategories, useCreateCategoryHierarchy, useAssignCategoryToHierarchy, useRemoveCategoryFromHierarchy, useSetupDefaultHierarchies, useDeleteCategoryHierarchy, useReorderCategoryHierarchies } from '@/hooks/use-category-hierarchies';
 import { SortableHierarchyList } from '@/components/hierarchy/sortable-hierarchy-list';
 import { CollapsiblePLPreview } from '@/components/hierarchy/collapsible-pl-preview';
@@ -50,9 +50,28 @@ export default function CategoriesPage() {
   };
 
   const handleDeleteCategory = async (categoryId: string, categoryName: string) => {
+    let impactSummary = `Are you sure you want to delete the category "${categoryName}"? This action cannot be undone.`;
+    try {
+      const impact = await fetchCategoryDeleteImpact(categoryId);
+      const lines: string[] = [];
+      if (impact.transactions > 0) lines.push(`• ${impact.transactions} transaction${impact.transactions === 1 ? '' : 's'} will be detached (moved back to Uncategorised)`);
+      if (impact.patterns > 0) lines.push(`• ${impact.patterns} categorisation pattern${impact.patterns === 1 ? '' : 's'} will be deleted`);
+      if (impact.hierarchyAssignments > 0) lines.push(`• ${impact.hierarchyAssignments} hierarchy assignment${impact.hierarchyAssignments === 1 ? '' : 's'} will be removed`);
+      if (impact.usageStats > 0) lines.push(`• ${impact.usageStats} usage-stats row${impact.usageStats === 1 ? '' : 's'} will be deleted`);
+      if (impact.childCategories > 0) lines.push(`• ${impact.childCategories} child categor${impact.childCategories === 1 ? 'y' : 'ies'} will be detached from this parent`);
+      if (impact.importedTestRows > 0) lines.push(`• ${impact.importedTestRows} legacy import row${impact.importedTestRows === 1 ? '' : 's'} will be cleaned up`);
+      if (lines.length === 0) {
+        impactSummary = `Delete the category "${categoryName}"? Nothing references it — this is a clean delete.`;
+      } else {
+        impactSummary = `Deleting "${categoryName}" will:\n${lines.join('\n')}\n\nThis cannot be undone.`;
+      }
+    } catch (error) {
+      console.error('Failed to compute delete impact:', error);
+    }
+
     showConfirmation({
       title: 'Delete Category',
-      description: `Are you sure you want to delete the category "${categoryName}"? This action cannot be undone.`,
+      description: impactSummary,
       confirmText: 'Delete',
       variant: 'destructive',
       onConfirm: async () => {

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -5,7 +5,6 @@ import { IncomeVsExpenditureChart } from '@/components/dashboard/income-vs-expen
 import { RecentTransactions } from '@/components/dashboard/recent-transactions';
 import { IncomeExpenditurePieChart } from '@/components/dashboard/category-pie-chart';
 import { PersonalBalanceCard } from '@/components/dashboard/personal-balance-card';
-import { LlmCostCard } from '@/components/dashboard/llm-cost-card';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
 function StatsCardsSkeleton() {
@@ -82,8 +81,6 @@ export default function DashboardPage() {
         </Suspense>
 
         <PersonalBalanceCard />
-
-        <LlmCostCard />
 
         {/* Main Content Grid - Professional Layout */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/components/dashboard/sidebar.tsx
+++ b/components/dashboard/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   LogOut,
   User,
   Database,
+  Sparkles,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { LucideIcon } from 'lucide-react';
@@ -71,6 +72,7 @@ const navigationSections: NavigationSection[] = [
       { name: 'Add Income', href: '/add-income', icon: TrendingUp },
       { name: 'Add Expenditure', href: '/add-expenditure', icon: TrendingDown },
       { name: 'Add Capital', href: '/add-capital', icon: Wallet },
+      { name: 'AI Usage', href: '/ai-usage', icon: Sparkles },
     ],
   },
   {

--- a/components/ui/confirmation-dialog.tsx
+++ b/components/ui/confirmation-dialog.tsx
@@ -52,7 +52,7 @@ export function ConfirmationDialog({
             )}
             {title}
           </DialogTitle>
-          <DialogDescription className="text-left">
+          <DialogDescription className="text-left whitespace-pre-line">
             {description}
           </DialogDescription>
         </DialogHeader>

--- a/hooks/use-categories.ts
+++ b/hooks/use-categories.ts
@@ -55,6 +55,40 @@ export function useCategories(type?: 'income' | 'expenditure' | 'capital') {
   });
 }
 
+export interface CategoryDeleteImpact {
+  transactions: number;
+  patterns: number;
+  hierarchyAssignments: number;
+  usageStats: number;
+  importedTestRows: number;
+  childCategories: number;
+}
+
+/**
+ * Counts everything that will be detached/deleted when a category is removed.
+ * Used to populate the delete confirmation dialog.
+ */
+export async function fetchCategoryDeleteImpact(id: string): Promise<CategoryDeleteImpact> {
+  const supabase = createClient();
+  const cnt = (q: { count: number | null }) => q.count ?? 0;
+  const [tx, pat, hier, stats, imp, kids] = await Promise.all([
+    supabase.from('transactions').select('id', { count: 'exact', head: true }).eq('category_id', id),
+    supabase.from('categorization_patterns').select('id', { count: 'exact', head: true }).eq('category_id', id),
+    supabase.from('category_hierarchy_assignments').select('id', { count: 'exact', head: true }).eq('category_id', id),
+    supabase.from('category_usage_stats').select('id', { count: 'exact', head: true }).eq('category_id', id),
+    supabase.from('imported_transactions_test').select('id', { count: 'exact', head: true }).eq('suggested_category_id', id),
+    supabase.from('categories').select('id', { count: 'exact', head: true }).eq('parent_id', id),
+  ]);
+  return {
+    transactions: cnt(tx),
+    patterns: cnt(pat),
+    hierarchyAssignments: cnt(hier),
+    usageStats: cnt(stats),
+    importedTestRows: cnt(imp),
+    childCategories: cnt(kids),
+  };
+}
+
 export function useCategoryMutations() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
@@ -148,44 +182,46 @@ export function useCategoryMutations() {
     },
   });
 
+  // Cascading delete: removes blocking dependents (patterns, hierarchy
+  // assignments, usage stats, imported_transactions_test rows), nulls out
+  // child categories' parent_id, detaches transactions (sets category_id =
+  // null — surfaces them in the uncategorised triage), then deletes the
+  // category itself.
   const deleteCategory = useMutation({
     mutationFn: async (id: string): Promise<void> => {
       if (!user?.id) throw new Error('User not authenticated');
-
       const supabase = createClient();
-      
-      // First check if category is in use by transactions
-      const { data: transactions, error: checkError } = await supabase
-        .from('transactions')
-        .select('id')
-        .eq('category_id', id)
-        .limit(1);
 
-      if (checkError) throw checkError;
-
-      if (transactions && transactions.length > 0) {
-        throw new Error('Cannot delete category that is in use by transactions. Please reassign or delete the transactions first.');
-      }
-
-      // Check if category is assigned to any hierarchies
-      const { data: hierarchyAssignments, error: hierarchyCheckError } = await supabase
-        .from('category_hierarchy_assignments')
-        .select('id')
-        .eq('category_id', id)
-        .limit(1);
-
-      if (hierarchyCheckError) throw hierarchyCheckError;
-
-      if (hierarchyAssignments && hierarchyAssignments.length > 0) {
-        throw new Error('Cannot delete category that is assigned to hierarchies. Please remove from hierarchies first.');
-      }
-
-      // Now delete the category
-      const { error } = await supabase
+      // 1. Detach child categories
+      const { error: childErr } = await supabase
         .from('categories')
-        .delete()
-        .eq('id', id);
+        .update({ parent_id: null })
+        .eq('parent_id', id);
+      if (childErr) throw childErr;
 
+      // 2. Remove FK-blocking dependents
+      const dependents = [
+        supabase.from('categorization_patterns').delete().eq('category_id', id),
+        supabase.from('category_hierarchy_assignments').delete().eq('category_id', id),
+        supabase.from('category_usage_stats').delete().eq('category_id', id),
+        supabase.from('imported_transactions_test').delete().eq('suggested_category_id', id),
+      ];
+      const results = await Promise.all(dependents);
+      for (const r of results) {
+        if (r.error) throw r.error;
+      }
+
+      // 3. Detach transactions explicitly (FK is ON DELETE SET NULL but we
+      // run it ourselves so the rows show up in queries that filter on
+      // category_id IS NULL immediately, before the category row is gone).
+      const { error: txErr } = await supabase
+        .from('transactions')
+        .update({ category_id: null })
+        .eq('category_id', id);
+      if (txErr) throw txErr;
+
+      // 4. Delete the category
+      const { error } = await supabase.from('categories').delete().eq('id', id);
       if (error) throw error;
     },
     onSuccess: () => {
@@ -194,15 +230,12 @@ export function useCategoryMutations() {
       queryClient.invalidateQueries({ queryKey: ['unallocated-categories'] });
       queryClient.invalidateQueries({ queryKey: ['unallocated-categories-stats'] });
       queryClient.invalidateQueries({ queryKey: ['category-hierarchies-with-categories'] });
+      queryClient.invalidateQueries({ queryKey: ['uncategorized-transactions'] });
       toast.success('Category deleted successfully!');
     },
     onError: (error: Error) => {
       console.error('Error deleting category:', error);
-      if (error.message.includes('in use')) {
-        toast.error('Cannot delete category that is in use by transactions');
-      } else {
-        toast.error('Failed to delete category. Please try again.');
-      }
+      toast.error(`Failed to delete category: ${error.message}`);
     },
   });
 


### PR DESCRIPTION
## Summary
- New \`/ai-usage\` page under **Data Management** nav. Moves the LLM cost card off the main dashboard (it was system-functionality cluttering the user-facing dashboard).
- **Cascading category delete.** The previous handler refused to delete any category with transactions or hierarchy assignments — Calvin couldn't remove stale test categories (Consulting, Client Management, etc.) that had legacy FK-blocking dependents.
  - New behaviour: removes blocking rows (\`categorization_patterns\`, \`category_hierarchy_assignments\`, \`category_usage_stats\`, \`imported_transactions_test\`), nulls out child categories' \`parent_id\`, detaches transactions back to Uncategorised, then deletes the category.
  - Confirm dialog now previews the impact: "3 transactions will be detached, 1 pattern will be deleted, …" — no surprises.

## Test plan
- [ ] Sidebar shows new "AI Usage" entry under Data Management
- [ ] /ai-usage renders the LLM cost card; main dashboard no longer shows it
- [ ] Delete a clean (no-dependents) category → "Nothing references it" message in dialog → deletes successfully
- [ ] Delete a category with transactions → dialog lists what will be detached → after confirm, transactions appear in /uncategorized
- [ ] Try deleting one of the stale Consulting / Client Management categories Calvin originally couldn't remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)