### PR TITLE
feat(cron): Phase A Session 3 — cron infra + observability

### DIFF
--- a/app/(dashboard)/ai-usage/page.tsx
+++ b/app/(dashboard)/ai-usage/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Sparkles } from 'lucide-react';
+import { Sparkles, Activity } from 'lucide-react';
 import { PageLayout, PageSection } from '@/components/ui/page-layout';
 import { LlmCostCard } from '@/components/dashboard/llm-cost-card';
+import { CronStatusCard } from '@/components/dashboard/cron-status-card';
 
 export default function AiUsagePage() {
   return (
@@ -11,6 +12,14 @@ export default function AiUsagePage() {
       description="OpenRouter / LLM cost tracking for the Gmail purchase classifier and any other AI features."
       icon={Sparkles}
     >
+      <PageSection
+        title="Cron health"
+        description="Status of the nightly gmail classifier. Goes red on failure or if the last run is older than 36 hours."
+        icon={Activity}
+      >
+        <CronStatusCard jobName="gmail-classifier" label="Gmail classifier · last run" />
+      </PageSection>
+
       <PageSection
         title="Spend"
         description="This month, lifetime, and how many transactions have been linked to a classified email."

--- a/components/dashboard/cron-status-card.tsx
+++ b/components/dashboard/cron-status-card.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { Activity, CheckCircle2, XCircle, AlertTriangle } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { useLastCronRun } from '@/hooks/use-last-cron-run';
+
+const STALE_HOURS = 36;
+
+interface Props {
+  jobName: string;
+  label: string;
+}
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.round(ms / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+function formatAbsolute(iso: string): string {
+  return new Date(iso).toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function CronStatusCard({ jobName, label }: Props) {
+  const { data: run, isLoading } = useLastCronRun(jobName);
+
+  if (isLoading) {
+    return (
+      <Card style={{ backgroundColor: '#1e1c27', borderColor: 'transparent' }} className="ring-1 ring-white/5">
+        <CardContent className="p-4">
+          <div className="h-12 bg-muted/30 rounded animate-pulse" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // No runs yet — show neutral "not yet run" state.
+  if (!run) {
+    return (
+      <Card style={{ backgroundColor: '#1e1c27', borderColor: 'transparent' }} className="ring-1 ring-white/5">
+        <CardContent className="p-4">
+          <div className="flex items-center gap-3">
+            <div className="rounded-md p-2" style={{ backgroundColor: 'rgba(151, 148, 168, 0.1)' }}>
+              <Activity className="h-4 w-4" style={{ color: '#9794a8' }} />
+            </div>
+            <div>
+              <div className="text-xs" style={{ color: '#9794a8' }}>{label}</div>
+              <div className="text-sm font-medium" style={{ color: '#cfcdd9' }}>Not yet run</div>
+              <div className="text-[11px]" style={{ color: '#9794a8' }}>The launchd job hasn&apos;t fired yet, or hasn&apos;t recorded a run.</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const ageHours = (Date.now() - new Date(run.finished_at).getTime()) / 3_600_000;
+  const stale = ageHours > STALE_HOURS;
+  const failed = !run.success;
+  const bad = failed || stale;
+
+  const palette = bad
+    ? { bg: 'rgba(239, 68, 68, 0.1)', accent: '#ef4444', Icon: XCircle }
+    : { bg: 'rgba(16, 185, 129, 0.1)', accent: '#10b981', Icon: CheckCircle2 };
+
+  const headline = failed
+    ? 'Last run failed'
+    : stale
+      ? 'Last run is stale'
+      : 'Healthy';
+
+  return (
+    <Card style={{ backgroundColor: '#1e1c27', borderColor: 'transparent' }} className="ring-1 ring-white/5">
+      <CardContent className="p-4">
+        <div className="flex items-start gap-3">
+          <div className="rounded-md p-2 flex-shrink-0" style={{ backgroundColor: palette.bg }}>
+            <palette.Icon className="h-4 w-4" style={{ color: palette.accent }} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <div className="text-xs" style={{ color: '#9794a8' }}>{label}</div>
+              {stale && !failed && (
+                <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide" style={{ color: '#f59e0b' }}>
+                  <AlertTriangle className="h-3 w-3" /> stale
+                </span>
+              )}
+            </div>
+            <div className="text-sm font-semibold" style={{ color: palette.accent }}>
+              {headline} · {formatRelative(run.finished_at)}
+            </div>
+            <div className="text-[11px]" style={{ color: '#9794a8' }}>
+              {formatAbsolute(run.finished_at)}
+              {run.summary && ` · ${run.summary}`}
+            </div>
+            {run.error_message && (
+              <div className="text-[11px] mt-1 line-clamp-2" style={{ color: '#fca5a5' }}>
+                {run.error_message}
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-last-cron-run.ts
+++ b/hooks/use-last-cron-run.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/supabase/client';
+import { useAuth } from '@/lib/auth-context';
+
+export interface CronRun {
+  id: string;
+  job_name: string;
+  started_at: string;
+  finished_at: string;
+  success: boolean;
+  summary: string | null;
+  error_message: string | null;
+  classified: number | null;
+  inserted: number | null;
+  matched: number | null;
+  cost_usd: number | null;
+}
+
+/**
+ * Fetch the most recent cron_runs row for a given job. Returns null if no
+ * runs have happened yet. UI is responsible for flagging stale runs (a run
+ * older than ~36h while the cron is supposed to be daily indicates trouble).
+ */
+export function useLastCronRun(jobName: string) {
+  const { user } = useAuth();
+
+  return useQuery<CronRun | null>({
+    queryKey: ['last-cron-run', jobName, user?.id],
+    enabled: !!user?.id,
+    staleTime: 60 * 1000,
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data, error } = await supabase
+        .from('cron_runs')
+        .select('*')
+        .eq('job_name', jobName)
+        .order('finished_at', { ascending: false })
+        .limit(1);
+      if (error) throw error;
+      return (data?.[0] as CronRun | undefined) ?? null;
+    },
+  });
+}

--- a/scripts/cron/run-classifier.sh
+++ b/scripts/cron/run-classifier.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Wrapper for the nightly gmail classifier (issue #13 Session 3).
+#
+# launchd invokes this; we cd, set PATH, run the classifier, and append
+# stdout/stderr to a date-stamped log file. The classifier writes its own
+# cron_runs row — this wrapper only owns the log and the PATH.
+
+set -u
+
+PROJECT_DIR="/Users/admin/Dev/Projects/herbarium-finance"
+LOG_DIR="/Users/admin/Logs/herbarium"
+LOG="$LOG_DIR/gmail-classifier-$(date +%Y-%m-%d).log"
+
+mkdir -p "$LOG_DIR"
+cd "$PROJECT_DIR" || { echo "fatal: cannot cd to $PROJECT_DIR" >&2; exit 2; }
+
+# launchd has a minimal PATH; explicitly include the user's npm-global,
+# homebrew, and system bins. Node + pnpm live under ~/.npm-global on this Mini.
+export PATH="/Users/admin/.npm-global/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+# gog uses an encrypted file keyring; under launchd there's no TTY to prompt
+# for the master password, so pull it from macOS Keychain (entry created with
+# `security add-generic-password -s gog-keyring-password -a $USER -w ...`).
+GOG_KEYRING_PASSWORD=$(/usr/bin/security find-generic-password -a "$USER" -s "gog-keyring-password" -w 2>/dev/null)
+if [ -z "$GOG_KEYRING_PASSWORD" ]; then
+  echo "fatal: gog-keyring-password not found in macOS Keychain" >&2
+  exit 3
+fi
+export GOG_KEYRING_PASSWORD
+
+{
+  echo "=== run started $(date '+%Y-%m-%d %H:%M:%S %z') ==="
+  /Users/admin/.npm-global/bin/pnpm classify-emails
+  rc=$?
+  echo "=== run finished $(date '+%Y-%m-%d %H:%M:%S %z') rc=$rc ==="
+  exit $rc
+} >> "$LOG" 2>&1

--- a/scripts/gmail-classifier/classify.ts
+++ b/scripts/gmail-classifier/classify.ts
@@ -16,9 +16,11 @@
 import { LOOKBACK_DAYS, MAX_PER_VENDOR, VENDORS, OPENROUTER_MODEL } from './config';
 import { searchThreads, getThreadMessages, getHeaders, getBodyText } from './gog';
 import { classifyEmail } from './openrouter';
-import { persistClassification, getKnownMessageIds } from './db';
+import { persistClassification, getKnownMessageIds, recordCronRun } from './db';
 import { runMatchingPass } from './matching';
 import type { GmailMessage } from './types';
+
+const JOB_NAME = 'gmail-classifier';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -113,47 +115,98 @@ async function processVendor(
 }
 
 async function main(): Promise<void> {
+  const startedAt = new Date().toISOString();
   console.log(`gmail-classifier ${DRY_RUN ? '(DRY-RUN)' : ''} — model=${OPENROUTER_MODEL}, lookback=${LOOKBACK_DAYS}d, max-per-vendor=${MAX_PER_VENDOR}`);
 
-  // Pre-flight: pull known message IDs once, share across vendors.
-  const knownIds = DRY_RUN ? new Set<string>() : await getKnownMessageIds();
-  if (knownIds.size > 0) console.log(`(${knownIds.size} already-classified messages will be skipped)`);
+  let totals = { fetched: 0, skipped: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0 };
+  let matchedCount = 0;
+  let summary = '';
+  let success = true;
+  let errorMessage: string | null = null;
 
-  const allStats: VendorStats[] = [];
-  for (const vendor of VENDORS) {
-    process.stdout.write(`→ ${vendor.name}: `);
-    try {
-      const stats = await processVendor(vendor, knownIds);
-      allStats.push(stats);
-      console.log(`${stats.fetched} fetched, ${stats.skipped} skipped, ${stats.classified} classified, ${stats.inserted} new, ${stats.errors} err, $${fmt(stats.cost_usd)}`);
-    } catch (e) {
-      console.log(`! ${(e as Error).message}`);
+  try {
+    // Pre-flight: pull known message IDs once, share across vendors.
+    const knownIds = DRY_RUN ? new Set<string>() : await getKnownMessageIds();
+    if (knownIds.size > 0) console.log(`(${knownIds.size} already-classified messages will be skipped)`);
+
+    const allStats: VendorStats[] = [];
+    const vendorErrors: string[] = [];
+    for (const vendor of VENDORS) {
+      process.stdout.write(`→ ${vendor.name}: `);
+      try {
+        const stats = await processVendor(vendor, knownIds);
+        allStats.push(stats);
+        console.log(`${stats.fetched} fetched, ${stats.skipped} skipped, ${stats.classified} classified, ${stats.inserted} new, ${stats.errors} err, $${fmt(stats.cost_usd)}`);
+      } catch (e) {
+        const msg = (e as Error).message;
+        vendorErrors.push(`${vendor.name}: ${msg}`);
+        console.log(`! ${msg}`);
+      }
     }
+
+    // Fail loud: if every vendor errored, the whole run failed (almost
+    // certainly an auth/connectivity issue, not a per-message hiccup).
+    if (vendorErrors.length > 0 && allStats.length === 0) {
+      throw new Error(`all vendors failed: ${vendorErrors.join(' | ')}`);
+    }
+
+    totals = allStats.reduce(
+      (acc, s) => ({
+        fetched: acc.fetched + s.fetched,
+        skipped: acc.skipped + s.skipped,
+        classified: acc.classified + s.classified,
+        inserted: acc.inserted + s.inserted,
+        duplicates: acc.duplicates + s.duplicates,
+        errors: acc.errors + s.errors,
+        cost_usd: acc.cost_usd + s.cost_usd,
+      }),
+      { fetched: 0, skipped: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0 },
+    );
+    console.log(`\nTotal: ${totals.fetched} fetched, ${totals.skipped} skipped, ${totals.classified} classified, ${totals.inserted} new, ${totals.errors} err, $${fmt(totals.cost_usd)}`);
+
+    if (!DRY_RUN) {
+      const m = await runMatchingPass();
+      matchedCount = m.matched;
+      console.log(`Matching: ${m.considered} considered, ${m.matched} matched, ${m.ambiguous} ambiguous, ${m.no_candidate} no candidate`);
+      summary = `${totals.inserted} new, ${m.matched}/${m.considered} matched, $${fmt(totals.cost_usd)}`;
+    } else {
+      summary = `(dry-run) ${totals.classified} classified, $${fmt(totals.cost_usd)}`;
+    }
+  } catch (e) {
+    success = false;
+    errorMessage = (e as Error).message;
+    console.error('run failed:', errorMessage);
   }
 
-  const total = allStats.reduce(
-    (acc, s) => ({
-      fetched: acc.fetched + s.fetched,
-      skipped: acc.skipped + s.skipped,
-      classified: acc.classified + s.classified,
-      inserted: acc.inserted + s.inserted,
-      duplicates: acc.duplicates + s.duplicates,
-      errors: acc.errors + s.errors,
-      cost_usd: acc.cost_usd + s.cost_usd,
-    }),
-    { fetched: 0, skipped: 0, classified: 0, inserted: 0, duplicates: 0, errors: 0, cost_usd: 0 },
-  );
-  console.log(`\nTotal: ${total.fetched} fetched, ${total.skipped} skipped, ${total.classified} classified, ${total.inserted} new, ${total.errors} err, $${fmt(total.cost_usd)}`);
-
-  // Matching pass — link unmatched classifications to bank transactions.
-  // Skipped on dry-run since nothing was inserted.
+  // Always record the run, success or failure, unless this is a dry-run.
   if (!DRY_RUN) {
-    const m = await runMatchingPass();
-    console.log(`Matching: ${m.considered} considered, ${m.matched} matched, ${m.ambiguous} ambiguous, ${m.no_candidate} no candidate`);
+    await recordCronRun({
+      job_name: JOB_NAME,
+      started_at: startedAt,
+      success,
+      summary,
+      error_message: errorMessage,
+      classified: totals.classified,
+      inserted: totals.inserted,
+      matched: matchedCount,
+      cost_usd: totals.cost_usd,
+    });
   }
+
+  if (!success) process.exit(1);
 }
 
-main().catch((e) => {
+main().catch(async (e) => {
   console.error('fatal:', e);
+  // Best-effort death notice. Started_at is approximate.
+  try {
+    await recordCronRun({
+      job_name: JOB_NAME,
+      started_at: new Date().toISOString(),
+      success: false,
+      summary: null,
+      error_message: `uncaught: ${(e as Error).message}`,
+    });
+  } catch { /* swallow — already exiting nonzero */ }
   process.exit(1);
 });

--- a/scripts/gmail-classifier/db.ts
+++ b/scripts/gmail-classifier/db.ts
@@ -21,6 +21,38 @@ export function getServiceClient(): SupabaseClient {
   return _client;
 }
 
+export interface CronRunRecord {
+  job_name: string;
+  started_at: string; // ISO
+  success: boolean;
+  summary?: string | null;
+  error_message?: string | null;
+  classified?: number | null;
+  inserted?: number | null;
+  matched?: number | null;
+  cost_usd?: number | null;
+}
+
+/** Insert a row into cron_runs. Best-effort — caller doesn't await failure. */
+export async function recordCronRun(row: CronRunRecord): Promise<void> {
+  const supabase = getServiceClient();
+  const { error } = await supabase.from('cron_runs').insert({
+    job_name: row.job_name,
+    started_at: row.started_at,
+    success: row.success,
+    summary: row.summary ?? null,
+    error_message: row.error_message ?? null,
+    classified: row.classified ?? null,
+    inserted: row.inserted ?? null,
+    matched: row.matched ?? null,
+    cost_usd: row.cost_usd ?? null,
+  });
+  if (error) {
+    // Don't throw — we don't want to mask the original failure (if any).
+    console.error('failed to record cron_runs row:', error.message);
+  }
+}
+
 /** Fetch the set of gmail_msg_ids already classified for the target user. */
 export async function getKnownMessageIds(): Promise<Set<string>> {
   const supabase = getServiceClient();

--- a/scripts/launchd/com.calvin.herbarium.gmail-classifier.plist
+++ b/scripts/launchd/com.calvin.herbarium.gmail-classifier.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.calvin.herbarium.gmail-classifier</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/admin/Dev/Projects/herbarium-finance/scripts/cron/run-classifier.sh</string>
+    </array>
+
+    <!-- Nightly at 02:00 -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <!-- Run on plist load / Mini reboot so we catch up immediately -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- launchd's own stdout/stderr capture as a backup; the wrapper writes
+         the human-friendly date-stamped logs. -->
+    <key>StandardOutPath</key>
+    <string>/Users/admin/Logs/herbarium/launchd-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/admin/Logs/herbarium/launchd-stderr.log</string>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/admin/Dev/Projects/herbarium-finance</string>
+</dict>
+</plist>

--- a/supabase/migrations/014_cron_runs.sql
+++ b/supabase/migrations/014_cron_runs.sql
@@ -1,0 +1,50 @@
+-- Migration 014 — cron_runs table (issue #13 Session 3)
+--
+-- Records every cron job execution for observability. Phase A only writes
+-- gmail-classifier rows here, but the schema is generic so future cron jobs
+-- can share it (just pick a unique job_name).
+--
+-- Source of truth for "last run status" tile on /ai-usage. The classifier
+-- script writes a row at the end of main() — success or caught failure.
+-- An uncaught crash leaves no row; the UI tile flags "no run >36h" as stale.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS cron_runs (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_name        text NOT NULL,
+  started_at      timestamptz NOT NULL,
+  finished_at     timestamptz NOT NULL DEFAULT now(),
+  success         boolean NOT NULL,
+  summary         text,
+  error_message   text,
+
+  -- Gmail-classifier-specific aggregates (NULL for other jobs)
+  classified      integer,
+  inserted        integer,
+  matched         integer,
+  cost_usd        numeric(10, 6),
+
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS cron_runs_job_finished_idx
+  ON cron_runs (job_name, finished_at DESC);
+
+ALTER TABLE cron_runs ENABLE ROW LEVEL SECURITY;
+
+-- Shared visibility (consistent with project convention since mig 013).
+-- Inserts come from service-role key which bypasses RLS, so no INSERT policy
+-- is needed for the cron itself; the policy is here in case a human action
+-- ever wants to record one (rare).
+CREATE POLICY "Authenticated users can view all cron runs"
+  ON cron_runs FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Authenticated users can insert cron runs"
+  ON cron_runs FOR INSERT
+  WITH CHECK (auth.role() = 'authenticated');
+
+-- No UPDATE/DELETE — cron history is immutable audit data.
+
+COMMIT;


### PR DESCRIPTION
Closes Session 3 of the Phase A plan (\`~/shared/markviewer/herbarium-finance/2026-04-30-phase-a-plan.md\`).

## What landed
- **Migration 014: \`cron_runs\` table** — generic schema, shared RLS, immutable. Applied to prod 2026-04-30.
- **classify.ts** records a row on every run, success or failure. Fail-loud fix: if every vendor errors out, the run is now flagged failed instead of "0 fetched, success".
- **\`scripts/cron/run-classifier.sh\`** — launchd wrapper. Pulls the gog keyring password from macOS Keychain (entry \`gog-keyring-password\`) so it works in launchd's TTY-less context.
- **\`scripts/launchd/com.calvin.herbarium.gmail-classifier.plist\`** — daily 02:00 + \`RunAtLoad: true\`.
- **/ai-usage \"Cron health\" section** — last-run tile, green inside 36h + success, red on failure or stale.

## Tested on the Mini
- Plist loaded via \`launchctl load\` — three \`cron_runs\` rows in prod (one manual + two via launchd)
- Keyring unlocks; gog → OpenRouter → DB pipeline runs cleanly under launchd
- Summary line renders correctly in the UI tile

## Operator notes (post-merge, no action needed unless something breaks)
- Plist already loaded on the Mini; daily run scheduled for 02:00
- Logs land at \`~/Logs/herbarium/gmail-classifier-YYYY-MM-DD.log\`
- New keychain entry: \`gog-keyring-password\` (don't delete)

## Test plan
- [ ] Visit /ai-usage — Cron Health card shows green status with recent run
- [ ] Wait for tomorrow's 02:00 run (or run \`launchctl start com.calvin.herbarium.gmail-classifier\`) — new row visible
- [ ] Sanity: temporarily break the wrapper (e.g. wrong PATH), reload plist, confirm UI goes red

## Next sessions (per plan)
- Session 4: measurement instrumentation (match-rate view, confidence histogram, dismissed flag)
- Session 5: 2-week soak + Phase B handoff doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)